### PR TITLE
[Feat] Quizbook 관련 API 구현

### DIFF
--- a/src/common/decorators/base-response.decorator.ts
+++ b/src/common/decorators/base-response.decorator.ts
@@ -1,0 +1,45 @@
+import { applyDecorators, HttpStatus, Type } from '@nestjs/common';
+import { ApiExtraModels, ApiResponse, getSchemaPath } from '@nestjs/swagger';
+import { BaseResponse } from '../dto/base-response.dto';
+
+/**
+ * Swagger의 API 응답을 BaseResponse<T> 형태로 감싸는 커스텀 데코레이터
+ * @param model - 실제 응답값에 적용될 데이터 모델
+ * @param statusCode - 응답 상태 코드 (기본값 200)
+ * @param description - 응답에 대한 설명 (Optional)
+ */
+export const ApiBaseResponse = <TModel extends Type<unknown>>(
+	model: TModel | TModel[],
+	statusCode: number = HttpStatus.OK,
+	description?: string,
+) => {
+	const isArrayType = Array.isArray(model);
+	const schemaModel = model instanceof Array ? model[0] : model;
+
+	const apiResponseOptions: Record<string, any> = {
+		status: statusCode,
+		description,
+		schema: {
+			allOf: [
+				{ $ref: getSchemaPath(BaseResponse) },
+				{
+					properties: {
+						statusCode: { type: 'number', example: statusCode },
+						message: { type: 'string', example: 'ok' },
+						data: isArrayType
+							? {
+									type: 'array',
+									items: { $ref: getSchemaPath(schemaModel) },
+								} // ✅ 배열이면 자동으로 감싸기
+							: { $ref: getSchemaPath(schemaModel) },
+					},
+				},
+			],
+		},
+	};
+
+	return applyDecorators(
+		ApiExtraModels(BaseResponse, schemaModel),
+		ApiResponse(apiResponseOptions),
+	);
+};

--- a/src/common/dto/base-response.dto.ts
+++ b/src/common/dto/base-response.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class BaseResponse<T> {
+	constructor(statusCode: number, message: string, data?: T) {
+		this.statusCode = statusCode;
+		this.message = message;
+		this.data = data;
+	}
+
+	@ApiProperty({ example: 200, description: 'HTTP 상태 코드' })
+	statusCode: number;
+
+	@ApiProperty({ example: 'ok', description: '응답 메시지' })
+	message: string;
+
+	@ApiProperty({ description: '응답 데이터', required: false })
+	data?: T;
+}

--- a/src/common/interceptors/global-response.interceptor.ts
+++ b/src/common/interceptors/global-response.interceptor.ts
@@ -6,34 +6,23 @@ import {
 } from '@nestjs/common';
 import { Response } from 'express';
 import { map, Observable } from 'rxjs';
-
-interface ApiResponse<T> {
-	statusCode: number;
-	message: string;
-	data: T;
-}
+import { BaseResponse } from '../dto/base-response.dto';
 
 @Injectable()
 export class GlobalResponseInterceptor<T>
-	implements NestInterceptor<T, ApiResponse<T>>
+	implements NestInterceptor<T, BaseResponse<T>>
 {
 	intercept(
 		context: ExecutionContext,
 		next: CallHandler<T>,
-	): Observable<ApiResponse<T>> {
+	): Observable<BaseResponse<T>> {
 		const response = context.switchToHttp().getResponse<Response>();
 
 		return next.handle().pipe(
 			map((data: T) => {
-				if (response.statusCode >= 200 && response.statusCode < 300) {
-					return {
-						statusCode: response.statusCode,
-						message: 'ok',
-						data,
-					};
-				}
+				const statusCode = response.statusCode; // 기본값 200 OK
 
-				return data as unknown as ApiResponse<T>; // ✅ 타입 강제 변환으로 오류 방지
+				return new BaseResponse(statusCode, 'ok', data);
 			}),
 		);
 	}

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ async function bootstrap() {
 		.setTitle('QuizBank')
 		.setDescription('QuizBank API 명세')
 		.setVersion('1.0')
+		.addServer('/v1')
 		.build();
 
 	const document = SwaggerModule.createDocument(app, config);

--- a/src/modules/quiz/dto/create-quiz.dto.ts
+++ b/src/modules/quiz/dto/create-quiz.dto.ts
@@ -1,1 +1,0 @@
-export class CreateQuizDto {}

--- a/src/modules/quiz/dto/update-quiz.dto.ts
+++ b/src/modules/quiz/dto/update-quiz.dto.ts
@@ -1,4 +1,0 @@
-import { PartialType } from '@nestjs/swagger';
-import { CreateQuizDto } from './create-quiz.dto';
-
-export class UpdateQuizDto extends PartialType(CreateQuizDto) {}

--- a/src/modules/quiz/entities/quiz.entity.ts
+++ b/src/modules/quiz/entities/quiz.entity.ts
@@ -1,1 +1,0 @@
-export class Quiz {}

--- a/src/modules/quiz/quiz.controller.ts
+++ b/src/modules/quiz/quiz.controller.ts
@@ -1,42 +1,24 @@
-import {
-	Controller,
-	Get,
-	Post,
-	Body,
-	Patch,
-	Param,
-	Delete,
-} from '@nestjs/common';
+import { Controller, Get, HttpStatus, Param, Version } from '@nestjs/common';
 import { QuizService } from './quiz.service';
-import { CreateQuizDto } from './dto/create-quiz.dto';
-import { UpdateQuizDto } from './dto/update-quiz.dto';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiBaseResponse } from 'src/common/decorators/base-response.decorator';
+import { Quiz } from './schema/quiz.schema';
 
 @Controller('quiz')
+@ApiTags('Quiz')
 export class QuizController {
 	constructor(private readonly quizService: QuizService) {}
 
-	@Post()
-	create(@Body() createQuizDto: CreateQuizDto) {
-		return this.quizService.create(createQuizDto);
-	}
-
-	@Get()
-	findAll() {
-		return this.quizService.findAll();
-	}
-
+	// GET v1/quiz/:id
+	// 특정 Quiz를 가져온다.
 	@Get(':id')
+	@Version('1')
+	@ApiOperation({
+		summary: '퀴즈 조회',
+		description: '특정 퀴즈를 가져옵니다.',
+	})
+	@ApiBaseResponse(Quiz, HttpStatus.OK, '조회 성공')
 	findOne(@Param('id') id: string) {
-		return this.quizService.findOne(+id);
-	}
-
-	@Patch(':id')
-	update(@Param('id') id: string, @Body() updateQuizDto: UpdateQuizDto) {
-		return this.quizService.update(+id, updateQuizDto);
-	}
-
-	@Delete(':id')
-	remove(@Param('id') id: string) {
-		return this.quizService.remove(+id);
+		return this.quizService.findOne(id);
 	}
 }

--- a/src/modules/quiz/quiz.module.ts
+++ b/src/modules/quiz/quiz.module.ts
@@ -1,9 +1,19 @@
 import { Module } from '@nestjs/common';
 import { QuizService } from './quiz.service';
 import { QuizController } from './quiz.controller';
+import { MongooseModule } from '@nestjs/mongoose';
+import { Quiz, QuizSchema } from './schema/quiz.schema';
+import { DB_TYPE } from 'src/database/database.const';
 
 @Module({
+	imports: [
+		MongooseModule.forFeature(
+			[{ name: Quiz.name, schema: QuizSchema }],
+			DB_TYPE.DEFAULT,
+		),
+	],
 	controllers: [QuizController],
 	providers: [QuizService],
+	exports: [QuizService],
 })
 export class QuizModule {}

--- a/src/modules/quiz/quiz.service.ts
+++ b/src/modules/quiz/quiz.service.ts
@@ -1,26 +1,23 @@
-import { Injectable } from '@nestjs/common';
-import { CreateQuizDto } from './dto/create-quiz.dto';
-import { UpdateQuizDto } from './dto/update-quiz.dto';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Quiz } from './schema/quiz.schema';
+import { DB_TYPE } from 'src/database/database.const';
+import { Model } from 'mongoose';
 
 @Injectable()
 export class QuizService {
-	create(createQuizDto: CreateQuizDto) {
-		return 'This action adds a new quiz';
-	}
+	constructor(
+		@InjectModel(Quiz.name, DB_TYPE.DEFAULT)
+		private readonly quizModel: Model<Quiz>,
+	) {}
 
-	findAll() {
-		return `This action returns all quiz`;
-	}
+	// 특정 Quiz를 가져온다.
+	async findOne(id: string) {
+		const quiz = await this.quizModel.findOne({ _id: id });
 
-	findOne(id: number) {
-		return `This action returns a #${id} quiz`;
-	}
+		if (!quiz)
+			throw new NotFoundException(`${id} 문제를 찾을 수 없습니다.`);
 
-	update(id: number, updateQuizDto: UpdateQuizDto) {
-		return `This action updates a #${id} quiz`;
-	}
-
-	remove(id: number) {
-		return `This action removes a #${id} quiz`;
+		return quiz;
 	}
 }

--- a/src/modules/quiz/schema/quiz.schema.ts
+++ b/src/modules/quiz/schema/quiz.schema.ts
@@ -1,28 +1,53 @@
 import { Document } from 'mongoose';
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { ApiProperty } from '@nestjs/swagger';
 
 export enum QuizType {
-	MULTIPLE_CHOICE = 'multiple_choice',
-	SHORT_ANSWER = 'short_answer',
-	LONG_ANSWER = 'long_answer',
+	MULTIPLE_CHOICE = '객관식',
+	SHORT_ANSWER = '주관식',
+	LONG_ANSWER = '서술형',
 	OX = 'ox',
 }
 
 @Schema({ timestamps: true })
 export class Quiz extends Document {
+	@ApiProperty({
+		example: '65e8a5d6fc13ae5e7f000002',
+		description: '퀴즈 UUID',
+	})
+	_id: string;
+
+	@ApiProperty({
+		enum: QuizType,
+		example: QuizType.MULTIPLE_CHOICE,
+		description: '퀴즈 유형',
+	})
 	@Prop({ required: true, enum: QuizType })
 	type: QuizType;
 
+	@ApiProperty({
+		example: '퀵 정렬의 시간 복잡도는?',
+		description: '퀴즈 질문',
+	})
 	@Prop({ required: true })
 	question: string;
 
+	@ApiProperty({
+		example: 'O(n log n)',
+		description: '퀴즈 정답',
+	})
 	@Prop({ required: true })
 	answer: string;
 
+	@ApiProperty({
+		example: ['O(n log n)', 'O(n)', 'O(n^2)', 'O(1)'],
+		description: '객관식 문제의 선택지 (객관식일 경우 필수)',
+		required: false,
+	})
 	@Prop({
 		type: [String],
 	})
-	options?: string[];
+	optionList?: string[];
 }
 
 export const QuizSchema = SchemaFactory.createForClass(Quiz);
@@ -31,7 +56,7 @@ export const QuizSchema = SchemaFactory.createForClass(Quiz);
 QuizSchema.pre('validate', function (next) {
 	if (
 		this.type === QuizType.MULTIPLE_CHOICE &&
-		(!this.options || this.options.length !== 4)
+		(!this.optionList || this.optionList.length !== 4)
 	) {
 		return next(new Error('객관식 문제는 4개의 보기를 포함해야 합니다.'));
 	}

--- a/src/modules/quizbook/dto/create-quizbook.dto.ts
+++ b/src/modules/quizbook/dto/create-quizbook.dto.ts
@@ -1,1 +1,107 @@
-export class CreateQuizbookDto {}
+import {
+	ArrayMaxSize,
+	ArrayMinSize,
+	IsArray,
+	IsEnum,
+	IsNotEmpty,
+	IsOptional,
+	IsString,
+	ValidateNested,
+} from 'class-validator';
+import { CategoryType } from '../schema/quizbook.schema';
+import { QuizType } from 'src/modules/quiz/schema/quiz.schema';
+import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class QuizItemDto {
+	@ApiProperty({
+		example: '퀵 정렬의 시간 복잡도는?',
+		description: '퀴즈 질문',
+	})
+	@IsString({
+		message: "'question' 필드는 문자열(String) 형식이어야 합니다.",
+	})
+	@IsNotEmpty({ message: "'question' 필드는 필수 입력 항목입니다." })
+	question: string;
+
+	@ApiProperty({
+		example: 'O(n log n)',
+		description: '퀴즈 정답',
+	})
+	@IsString({ message: "'answer' 필드는 문자열(String) 형식이어야 합니다." })
+	@IsNotEmpty({ message: "'answer' 필드는 필수 입력 항목입니다." })
+	answer: string;
+
+	@ApiProperty({
+		enum: QuizType,
+		example: QuizType.MULTIPLE_CHOICE,
+		description: '퀴즈 유형',
+	})
+	@IsEnum(QuizType, { message: "'type' 값은 유효한 퀴즈 유형이어야 합니다." })
+	type: QuizType;
+
+	@ApiProperty({
+		example: ['O(n log n)', 'O(n)', 'O(n^2)', 'O(1)'],
+		description: '객관식 문제의 선택지 (객관식일 경우 필수)',
+		required: false,
+	})
+	@IsOptional()
+	@IsArray({ message: "'options' 필드는 배열(Array) 형식이어야 합니다." })
+	@ArrayMaxSize(4, {
+		message: "'options' 필드는 정확히 4개의 항목을 포함해야 합니다.",
+	})
+	@ArrayMinSize(4, {
+		message: "'options' 필드는 정확히 4개의 항목을 포함해야 합니다.",
+	})
+	options?: string[];
+}
+
+export class CreateQuizbookDto {
+	@ApiProperty({
+		example: '알고리즘 문제집',
+		description: '퀴즈북 제목',
+	})
+	@IsString({ message: "'title' 필드는 문자열(String) 타입이어야 합니다." })
+	@IsNotEmpty({ message: "'title' 필드는 필수 입력 항목 입니다." })
+	title: string;
+
+	@ApiProperty({
+		example: CategoryType.ALGORITHM,
+		enum: CategoryType,
+		description: '문제집 카테고리',
+	})
+	@IsEnum(CategoryType, {
+		message: "'category' 필드의 값은 유효한 카테고리 값이어야 합니다.",
+	})
+	@IsNotEmpty({ message: "'category' 필드는 필수 입력 항목 입니다." })
+	category: CategoryType;
+
+	@ApiProperty({
+		example: '이 문제집은 알고리즘 면접을 준비하는 사람들을 위한 것입니다.',
+		description: '문제집 설명',
+	})
+	@IsString({
+		message: "'description' 필드는 문자열(String) 타입이어야 합니다.",
+	})
+	@IsNotEmpty({ message: "'description' 필드는 필수 입력 항목 입니다." })
+	description: string;
+
+	@ApiProperty({
+		type: [QuizItemDto],
+		description: '퀴즈 리스트',
+		example: [
+			{
+				question: '퀵 정렬의 시간 복잡도는?',
+				answer: 'O(n log n)',
+				type: QuizType.MULTIPLE_CHOICE,
+				optionList: ['O(n)', 'O(n log n)', 'O(n^2)', 'O(1)'],
+			},
+		],
+	})
+	@IsNotEmpty({
+		message: "'quizbook' 필드는 배열(Array) 형식이어야 합니다.",
+	})
+	@ValidateNested({ each: true })
+	@Type(() => QuizItemDto)
+	quizList: QuizItemDto[];
+}

--- a/src/modules/quizbook/dto/find-all-quizbook.dto.ts
+++ b/src/modules/quizbook/dto/find-all-quizbook.dto.ts
@@ -1,0 +1,22 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsOptional, IsString } from 'class-validator';
+import { CategoryType } from '../schema/quizbook.schema';
+
+export class FindAllQuizbookDto {
+	@ApiPropertyOptional({ description: '문제집 제목' })
+	@IsOptional()
+	@IsString()
+	title?: string;
+
+	@ApiPropertyOptional({
+		description: '문제집 설명',
+	})
+	@IsOptional()
+	@IsString()
+	description?: string;
+
+	@ApiPropertyOptional({ description: '문제집 카테고리', enum: CategoryType })
+	@IsOptional()
+	@IsEnum(CategoryType)
+	category?: CategoryType;
+}

--- a/src/modules/quizbook/dto/response-quizbook.dto.ts
+++ b/src/modules/quizbook/dto/response-quizbook.dto.ts
@@ -1,0 +1,33 @@
+import { ApiProperty, getSchemaPath } from '@nestjs/swagger';
+import { Quizbook } from '../schema/quizbook.schema';
+import { Types } from 'mongoose';
+import { Quiz } from 'src/modules/quiz/schema/quiz.schema';
+
+export class QuizbookCreateResponseDto extends Quizbook {
+	@ApiProperty({
+		type: 'array',
+		items: { type: 'string', format: 'uuid' },
+		example: ['65e8a5d6fc13ae5e7f000002'],
+		description: '문제집 생성시 quizList는 UUID 배열로 반환됨.',
+	})
+	quizList: Types.ObjectId[];
+}
+
+export class QuizbookFindAllResponseDto extends Quizbook {
+	@ApiProperty({
+		type: 'array',
+		items: { type: 'string', format: 'uuid' },
+		example: ['65e8a5d6fc13ae5e7f000002'],
+		description: '모든 문제집 조회시 quizList는 UUID 배열로 반환됨.',
+	})
+	quizList: Types.ObjectId[];
+}
+
+export class QuizbookFindOneResponseDto extends Quizbook {
+	@ApiProperty({
+		type: 'array',
+		items: { $ref: getSchemaPath(Quiz) },
+		description: '문제집 상세 조회 시 quizList는 Quiz 객체의 배열로 반환됨',
+	})
+	quizList: Quiz[];
+}

--- a/src/modules/quizbook/dto/update-quizbook.dto.ts
+++ b/src/modules/quizbook/dto/update-quizbook.dto.ts
@@ -1,4 +1,0 @@
-import { PartialType } from '@nestjs/swagger';
-import { CreateQuizbookDto } from './create-quizbook.dto';
-
-export class UpdateQuizbookDto extends PartialType(CreateQuizbookDto) {}

--- a/src/modules/quizbook/entities/quizbook.entity.ts
+++ b/src/modules/quizbook/entities/quizbook.entity.ts
@@ -1,1 +1,0 @@
-export class Quizbook {}

--- a/src/modules/quizbook/quizbook.controller.ts
+++ b/src/modules/quizbook/quizbook.controller.ts
@@ -3,43 +3,66 @@ import {
 	Get,
 	Post,
 	Body,
-	Patch,
 	Param,
-	Delete,
+	Version,
+	Query,
+	HttpStatus,
 } from '@nestjs/common';
 import { QuizbookService } from './quizbook.service';
 import { CreateQuizbookDto } from './dto/create-quizbook.dto';
-import { UpdateQuizbookDto } from './dto/update-quizbook.dto';
+import { ApiExtraModels, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { FindAllQuizbookDto } from './dto/find-all-quizbook.dto';
+import { Quizbook } from './schema/quizbook.schema';
+import { ApiBaseResponse } from 'src/common/decorators/base-response.decorator';
+import { Quiz } from '../quiz/schema/quiz.schema';
+import {
+	QuizbookCreateResponseDto,
+	QuizbookFindAllResponseDto,
+	QuizbookFindOneResponseDto,
+} from './dto/response-quizbook.dto';
 
 @Controller('quizbook')
+@ApiTags('Quizbook')
 export class QuizbookController {
 	constructor(private readonly quizbookService: QuizbookService) {}
 
+	// POST v1/quizbook
+	// 문제집을 생성한다.
 	@Post()
-	create(@Body() createQuizbookDto: CreateQuizbookDto) {
+	@Version('1')
+	@ApiOperation({
+		summary: '문제집 생성',
+		description: '문제집을 생성합니다.',
+	})
+	@ApiBaseResponse(QuizbookCreateResponseDto, HttpStatus.CREATED, '성공')
+	async create(@Body() createQuizbookDto: CreateQuizbookDto) {
 		return this.quizbookService.create(createQuizbookDto);
 	}
 
+	// GET v1/quizbook
+	// 모든 문제집을 가져온다.
 	@Get()
-	findAll() {
-		return this.quizbookService.findAll();
+	@Version('1')
+	@ApiOperation({
+		summary: '모든 문제집 조회',
+		description: '모든 문제집을 가져옵니다.',
+	})
+	@ApiBaseResponse([QuizbookFindAllResponseDto], HttpStatus.OK, '조회 성공')
+	async findAll(@Query() query: FindAllQuizbookDto) {
+		return this.quizbookService.findAll(query);
 	}
 
+	// GET v1/quizbook/:id
+	// 특정 문제집의 상세정보를 가져온다다.
 	@Get(':id')
-	findOne(@Param('id') id: string) {
-		return this.quizbookService.findOne(+id);
-	}
-
-	@Patch(':id')
-	update(
-		@Param('id') id: string,
-		@Body() updateQuizbookDto: UpdateQuizbookDto,
-	) {
-		return this.quizbookService.update(+id, updateQuizbookDto);
-	}
-
-	@Delete(':id')
-	remove(@Param('id') id: string) {
-		return this.quizbookService.remove(+id);
+	@Version('1')
+	@ApiOperation({
+		summary: '문제집 상세 조회',
+		description: '문제집의 상세정보를 가져옵니다.',
+	})
+	@ApiExtraModels(Quiz)
+	@ApiBaseResponse(QuizbookFindOneResponseDto, HttpStatus.OK, '조회 성공')
+	async findOne(@Param('id') id: string) {
+		return this.quizbookService.findOne(id);
 	}
 }

--- a/src/modules/quizbook/quizbook.controller.ts
+++ b/src/modules/quizbook/quizbook.controller.ts
@@ -33,7 +33,7 @@ export class QuizbookController {
 		summary: '문제집 생성',
 		description: '문제집을 생성합니다.',
 	})
-	@ApiBaseResponse(QuizbookCreateResponseDto, HttpStatus.CREATED, '성공')
+	@ApiBaseResponse(QuizbookCreateResponseDto, HttpStatus.CREATED, '생성 성공')
 	async create(@Body() createQuizbookDto: CreateQuizbookDto) {
 		return this.quizbookService.create(createQuizbookDto);
 	}
@@ -52,7 +52,7 @@ export class QuizbookController {
 	}
 
 	// GET v1/quizbook/:id
-	// 특정 문제집의 상세정보를 가져온다다.
+	// 특정 문제집의 상세정보를 가져온다.
 	@Get(':id')
 	@Version('1')
 	@ApiOperation({

--- a/src/modules/quizbook/quizbook.controller.ts
+++ b/src/modules/quizbook/quizbook.controller.ts
@@ -12,7 +12,6 @@ import { QuizbookService } from './quizbook.service';
 import { CreateQuizbookDto } from './dto/create-quizbook.dto';
 import { ApiExtraModels, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { FindAllQuizbookDto } from './dto/find-all-quizbook.dto';
-import { Quizbook } from './schema/quizbook.schema';
 import { ApiBaseResponse } from 'src/common/decorators/base-response.decorator';
 import { Quiz } from '../quiz/schema/quiz.schema';
 import {

--- a/src/modules/quizbook/quizbook.module.ts
+++ b/src/modules/quizbook/quizbook.module.ts
@@ -1,9 +1,23 @@
 import { Module } from '@nestjs/common';
 import { QuizbookService } from './quizbook.service';
 import { QuizbookController } from './quizbook.controller';
+import { MongooseModule } from '@nestjs/mongoose';
+import { Quizbook, QuizbookSchema } from './schema/quizbook.schema';
+import { Quiz, QuizSchema } from '../quiz/schema/quiz.schema';
+import { DB_TYPE } from 'src/database/database.const';
 
 @Module({
+	imports: [
+		MongooseModule.forFeature(
+			[
+				{ name: Quizbook.name, schema: QuizbookSchema },
+				{ name: Quiz.name, schema: QuizSchema },
+			],
+			DB_TYPE.DEFAULT,
+		),
+	],
 	controllers: [QuizbookController],
 	providers: [QuizbookService],
+	exports: [QuizbookService],
 })
 export class QuizbookModule {}

--- a/src/modules/quizbook/quizbook.service.ts
+++ b/src/modules/quizbook/quizbook.service.ts
@@ -1,26 +1,89 @@
-import { Injectable } from '@nestjs/common';
+import {
+	Injectable,
+	InternalServerErrorException,
+	NotFoundException,
+} from '@nestjs/common';
 import { CreateQuizbookDto } from './dto/create-quizbook.dto';
-import { UpdateQuizbookDto } from './dto/update-quizbook.dto';
+import { Quizbook } from './schema/quizbook.schema';
+import { FilterQuery, Model } from 'mongoose';
+import { DB_TYPE } from 'src/database/database.const';
+import { InjectModel } from '@nestjs/mongoose';
+import { Quiz } from '../quiz/schema/quiz.schema';
+import { FindAllQuizbookDto } from './dto/find-all-quizbook.dto';
 
 @Injectable()
 export class QuizbookService {
-	create(createQuizbookDto: CreateQuizbookDto) {
-		return 'This action adds a new quizbook';
+	constructor(
+		@InjectModel(Quizbook.name, DB_TYPE.DEFAULT)
+		private readonly quizbookModel: Model<Quizbook>,
+		@InjectModel(Quiz.name, DB_TYPE.DEFAULT)
+		private readonly quizModel: Model<Quiz>,
+	) {}
+	// Quizbook을 생성한다.
+	async create(createQuizbookDto: CreateQuizbookDto) {
+		// 트랜젝션 시작
+		const session = await this.quizbookModel.db.startSession();
+		session.startTransaction();
+
+		try {
+			// 1. Quiz 생성
+			const quizDocs = await this.quizModel.insertMany(
+				createQuizbookDto.quizList,
+				{ session },
+			);
+
+			// 2. Quizbook 생성
+			const quizbook: Quizbook = new this.quizbookModel({
+				title: createQuizbookDto.title,
+				category: createQuizbookDto.category,
+				description: createQuizbookDto.description,
+				quizzes: quizDocs.map((quiz) => quiz._id),
+			});
+
+			await quizbook.save({ session });
+
+			// 트랜젝션 커밋
+			await session.commitTransaction();
+			await session.endSession();
+
+			return quizbook;
+		} catch (e) {
+			// 오류 발생시 롤백
+			await session.abortTransaction();
+			throw new InternalServerErrorException(
+				'DB 데이터 생성 도중 에러가 발생했습니다.',
+			);
+		}
 	}
 
-	findAll() {
-		return `This action returns all quizbook`;
+	// 모든 Quizbook을 가져온다.
+	async findAll(query: FindAllQuizbookDto) {
+		const filters: FilterQuery<Quizbook> = {};
+
+		if (query.title) filters.title = { $regex: query.title, $options: 'i' };
+		if (query.description)
+			filters.description = { $regex: query.description, $options: 'i' };
+		if (query.category)
+			filters.category = { $regex: query.category, $options: 'i' };
+
+		const quizbooks = await this.quizbookModel.find(filters);
+
+		return quizbooks;
 	}
 
-	findOne(id: number) {
-		return `This action returns a #${id} quizbook`;
-	}
+	// 특정 Quizbook을 가져온다.
+	async findOne(id: string) {
+		const quizbook = await this.quizbookModel
+			.findOne({ _id: id })
+			.populate({
+				path: 'quizzes',
+				model: 'Quiz',
+				select: 'type question',
+			});
 
-	update(id: number, updateQuizbookDto: UpdateQuizbookDto) {
-		return `This action updates a #${id} quizbook`;
-	}
+		if (!quizbook)
+			throw new NotFoundException(`${id} 문제집을 찾을 수 없습니다.`);
 
-	remove(id: number) {
-		return `This action removes a #${id} quizbook`;
+		return quizbook;
 	}
 }

--- a/src/modules/quizbook/quizbook.service.ts
+++ b/src/modules/quizbook/quizbook.service.ts
@@ -76,7 +76,7 @@ export class QuizbookService {
 		const quizbook = await this.quizbookModel
 			.findOne({ _id: id })
 			.populate({
-				path: 'quizzes',
+				path: 'quizList',
 				model: 'Quiz',
 				select: 'type question',
 			});

--- a/src/modules/quizbook/schema/quizbook.schema.ts
+++ b/src/modules/quizbook/schema/quizbook.schema.ts
@@ -1,6 +1,7 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document, Types } from 'mongoose';
 import { Quiz } from '../../quiz/schema/quiz.schema';
+import { ApiProperty, getSchemaPath } from '@nestjs/swagger';
 
 export enum CategoryType {
 	DATA_STRUCTURE = '자료구조',
@@ -13,12 +14,25 @@ export enum CategoryType {
 
 @Schema({ timestamps: true })
 export class Quizbook extends Document {
+	@ApiProperty({
+		example: '알고리즘 문제집',
+		description: '퀴즈북 제목',
+	})
 	@Prop({ required: true })
 	title: string;
 
+	@ApiProperty({
+		example: '이 문제집은 알고리즘 면접을 준비하는 사람들을 위한 것입니다.',
+		description: '문제집 설명',
+	})
 	@Prop({ required: true })
 	description: string;
 
+	@ApiProperty({
+		example: CategoryType.ALGORITHM,
+		enum: CategoryType,
+		description: '문제집 카테고리',
+	})
 	@Prop({ required: true, enum: CategoryType })
 	category: CategoryType;
 
@@ -26,17 +40,21 @@ export class Quizbook extends Document {
 		type: [{ type: Types.ObjectId, ref: 'Quiz' }],
 		required: true,
 	})
-	quizzes: Types.ObjectId[] | Quiz[];
+	quizList: Types.ObjectId[] | Quiz[];
 
+	@ApiProperty({ example: 100, description: '문제집을 풀이한 사용자 수' })
 	@Prop({ default: 0 })
 	solvedCount: number;
 
+	@ApiProperty({ example: 85.5, description: '문제집 정답률(%)' })
 	@Prop({ default: 0 })
 	solvedRate: number;
 
+	@ApiProperty({ example: 10, description: '리뷰 수' })
 	@Prop({ default: 0 })
 	reviewCount: number;
 
+	@ApiProperty({ example: 4.5, description: '평균 리뷰 평점' })
 	@Prop({ default: 0 })
 	reviewRate: number;
 

--- a/src/modules/quizbook/schema/quizbook.schema.ts
+++ b/src/modules/quizbook/schema/quizbook.schema.ts
@@ -1,7 +1,7 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document, Types } from 'mongoose';
 import { Quiz } from '../../quiz/schema/quiz.schema';
-import { ApiProperty, getSchemaPath } from '@nestjs/swagger';
+import { ApiProperty } from '@nestjs/swagger';
 
 export enum CategoryType {
 	DATA_STRUCTURE = '자료구조',


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
- Swagger 공통 응답 커스텀 데코레이터 작성
- 공통 응답 DTO 작성
- Quizbook 관련 API 구현
- Quiz 관련 API 구현
- 구현 내용 Swagger 문서화

<br/>

## 📌 이슈 넘버
- #13 

<br/>

## 📝 작업 내용
### ✅ Quizbook 관련 API 구현
- `findAll()` → Query( `title`, `description`, `category` )를 활용한 문제집 목록 조회
- `findOne()` → Param(`id`)을 활용한 문제집 상세 조회
- `create()` → 문제집 생성

### ✅ Quiz 관련 API 구현
  - `findOne()` → Param( `id` )을 활용한 특정 퀴즈 조회

### ✅ 공통 응답 DTO (`base-response.dto.ts`) 작성
- 기존 응답을 래핑하던 `GlobalResponseInterceptor` 내부 로직을 수정
- 기존에는 일반 객체를 반환했으나, 이제 `BaseResponse` **인스턴스**를 생성하여 반환
- **응답 형태는 동일**하지만, 코드 일관성을 유지하면서 재 사용성을 향상

### ✅ Swagger 응답 Example을 위한 커스텀 데코레이터(`base-response.decorator.ts`) 작성
- 컨트롤러에서 `@ApiBaseResponse()`를 호출하여 Swagger 문서에 일관된 응답 형식을 적용 가능
- **사용 예시:**
```ts
  @Get()
  @Version('1')
  @ApiOperation({
  	summary: '모든 문제집 조회',
  	description: '모든 문제집을 가져옵니다.',
  })
  @ApiBaseResponse([QuizbookFindAllResponseDto], HttpStatus.OK, '조회 성공')
  async findAll(@Query() query: FindAllQuizbookDto) {
  	return this.quizbookService.findAll(query);
  }
```
- **`@ApiBaseResponse()` 인자 설명**
  - 첫 번째 인자: Swagger 응답 데이터의 구조(`@ApiProperty()`)를 정의한 DTO 또는 DB 스키마 (배열 형태도 가능).
  - 두 번째 인자: Swagger 문서에 표시될 HTTP 응답 상태 코드.
  - 세 번째 인자: Swagger 문서에 표시될 응답 설명.

### ❗제한사항
- MongoDB의 `populate()`를 사용하면 `ObjectId`**(UUID)** 배열과 실제 객체 배열을 반환하는 경우가 나뉘게 됨.
- 이러한 차이를 고려하여, **해당 필드를 별도로 분리하여 응답 DTO를 작성**해야 함.
- **DTO 예시:**
```ts
export class QuizbookCreateResponseDto extends Quizbook {
	@ApiProperty({
		type: 'array',
		items: { type: 'string', format: 'uuid' },
		example: ['65e8a5d6fc13ae5e7f000002'],
		description: '문제집 생성 시 quizList는 UUID 배열로 반환됩니다.',
	})
	quizList: Types.ObjectId[];
}

export class QuizbookFindAllResponseDto extends Quizbook {
	@ApiProperty({
		type: 'array',
		items: { type: 'string', format: 'uuid' },
		example: ['65e8a5d6fc13ae5e7f000002'],
		description: '모든 문제집 조회 시 quizList는 UUID 배열로 반환됩니다.',
	})
	quizList: Types.ObjectId[];
}

export class QuizbookFindOneResponseDto extends Quizbook {
	@ApiProperty({
		type: 'array',
		items: { $ref: getSchemaPath(Quiz) },
		description: '문제집 상세 조회 시 quizList는 Quiz 객체의 배열로 반환됩니다.',
	})
	quizList: Quiz[];
}
```
- **컨트롤러 예시:**
```ts
// GET v1/quizbook/:id
// 특정 문제집의 상세정보를 가져온다.
@Get(':id')
@Version('1')
@ApiOperation({
        summary: '문제집 상세 조회',
        description: '문제집의 상세정보를 가져옵니다.',
})
@ApiExtraModels(Quiz) // Swagger가 Quiz 모델을 인식할 수 있도록 등록
@ApiBaseResponse(QuizbookFindOneResponseDto, HttpStatus.OK, '조회 성공')
async findOne(@Param('id') id: string) {
        return this.quizbookService.findOne(id);
}
```

## 💬리뷰 요구사항
- 더 간단한 방법을 찾아보려 했지만, `populate()`로 참조되는 모델이 Swagger에서 정상적으로 인식되지 않아 이 방법을 선택했습니다.
- 최대한 이해하기 쉽게 작성하려고 했지만, 혹시 이해되지 않는 부분이나 수정이 필요한 부분이 있다면 코멘트나 Discord로 편하게 알려주세요! 😊

Closes #13 