### PR TITLE
[Feat] Group API에 GroupQuizbook 관련 로직 추가

### DIFF
--- a/src/modules/group/group-quizbook/group-quizbook.module.ts
+++ b/src/modules/group/group-quizbook/group-quizbook.module.ts
@@ -8,7 +8,6 @@ import {
 } from './schema/group-quizbook.schema';
 import { DB_TYPE } from 'src/database/database.const';
 import { DatabaseModule } from 'src/database/database.module';
-import { QuizbookModule } from 'src/modules/quizbook/quizbook.module';
 import { GroupQuizbookRepository } from './group-quizbook.repository';
 import { GroupModule } from '../group.module';
 
@@ -19,7 +18,6 @@ import { GroupModule } from '../group.module';
 			DB_TYPE.DEFAULT,
 		),
 		DatabaseModule,
-		QuizbookModule,
 		forwardRef(() => GroupModule),
 	],
 	controllers: [GroupQuizbookController],

--- a/src/modules/group/group-quizbook/group-quizbook.repository.ts
+++ b/src/modules/group/group-quizbook/group-quizbook.repository.ts
@@ -55,12 +55,21 @@ export class GroupQuizbookRepository {
 	}
 
 	/**
-	 * GroupQuizbook 삭제
+	 * GroupQuizbook 삭제 with filter
 	 */
 	async delete(groupId: string, quizbookId: string, session?: ClientSession) {
 		return this.groupQuizbookModel.findOneAndDelete(
 			{ group: toObjectId(groupId), quizbook: toObjectId(quizbookId) },
 			{ session },
 		);
+	}
+
+	/**
+	 * GroupQuizbook 삭제 by Id
+	 */
+	async deleteById(groupQuizbookId: string, session?: ClientSession) {
+		return this.groupQuizbookModel.findByIdAndDelete(groupQuizbookId, {
+			session,
+		});
 	}
 }

--- a/src/modules/group/group-quizbook/group-quizbook.service.ts
+++ b/src/modules/group/group-quizbook/group-quizbook.service.ts
@@ -4,7 +4,6 @@ import {
 	UnauthorizedException,
 } from '@nestjs/common';
 import { GroupQuizbookRepository } from './group-quizbook.repository';
-import { QuizbookRepository } from 'src/modules/quizbook/quizbook.repository';
 import { DatabaseService } from 'src/database/database.service';
 import { GroupRepository } from '../group.repository';
 import { toObjectId } from 'src/common/utils/database.util';
@@ -13,7 +12,6 @@ import { toObjectId } from 'src/common/utils/database.util';
 export class GroupQuizbookService {
 	constructor(
 		private readonly groupQuizbookRepository: GroupQuizbookRepository,
-		private readonly quizbookRepository: QuizbookRepository,
 		private readonly databaseService: DatabaseService,
 		private readonly groupRepository: GroupRepository,
 	) {}

--- a/src/modules/group/group.module.ts
+++ b/src/modules/group/group.module.ts
@@ -7,24 +7,19 @@ import { DB_TYPE } from 'src/database/database.const';
 import { GroupRepository } from './group.repository';
 import { DatabaseModule } from 'src/database/database.module';
 import { QuizbookModule } from '../quizbook/quizbook.module';
-import {
-	GroupQuizbook,
-	GroupQuizbookSchema,
-} from './group-quizbook/schema/group-quizbook.schema';
 import { AuthTokenModule } from '../auth/auth-token/auth-token.module';
+import { GroupQuizbookModule } from './group-quizbook/group-quizbook.module';
 
 @Module({
 	imports: [
 		MongooseModule.forFeature(
-			[
-				{ name: Group.name, schema: GroupSchema },
-				{ name: GroupQuizbook.name, schema: GroupQuizbookSchema },
-			],
+			[{ name: Group.name, schema: GroupSchema }],
 			DB_TYPE.DEFAULT,
 		),
 		DatabaseModule,
 		QuizbookModule,
 		AuthTokenModule,
+		GroupQuizbookModule,
 	],
 	controllers: [GroupController],
 	providers: [GroupService, GroupRepository],

--- a/src/modules/group/group.service.ts
+++ b/src/modules/group/group.service.ts
@@ -15,6 +15,7 @@ import { AuthTokenService } from '../auth/auth-token/auth-token.service';
 import { TokenType } from '../auth/auth-token/auth-token.types';
 import { InviteTokenPayloadDto } from './dto/invite-token-payload.dto';
 import { Quizbook } from '../quizbook/schema/quizbook.schema';
+import { GroupQuizbookRepository } from './group-quizbook/group-quizbook.repository';
 
 @Injectable()
 export class GroupService {
@@ -23,6 +24,7 @@ export class GroupService {
 		private readonly quizbookRepository: QuizbookRepository,
 		private readonly databaseService: DatabaseService,
 		private readonly authTokenService: AuthTokenService,
+		private readonly groupQuizbookRepository: GroupQuizbookRepository,
 	) {}
 
 	async makeImminentQuizbook(
@@ -183,7 +185,21 @@ export class GroupService {
 			if (group.admin._id.toString() !== userId)
 				throw new UnauthorizedException(`허가되지 않는 접근입니다.`);
 
-			// Group에 속한 모든 GroupQuizbook 제거 코드 추후에 추가.
+			await Promise.all(
+				group.groupQuizbookList.map(async (groupQuizbook) => {
+					const deletedGroupQuizbook =
+						await this.groupQuizbookRepository.deleteById(
+							groupQuizbook._id.toString(),
+							session,
+						);
+
+					if (!deletedGroupQuizbook)
+						throw new NotFoundException(
+							'Group의 해당 선정 문제집을 찾을 수 없습니다.',
+						);
+				}),
+			);
+
 			// ChatRoom 제거 코드 추후에 추가.
 
 			const deletedGroup = await this.groupRepository.delete(


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

- GroupQuizbook API 구현에 따라 Group API 로직에 관련 로직 코드 추가

## 📌 이슈 넘버

- #30 

## 📝 작업 내용

- GroupQuizbook Repository 메소드 추가
- 불필요한 코드들 제거
- Group Service의 deleteGroup 메소드에 Group에 속한 모든 GroupQuizbook 제거 로직 추가(하드 딜리트)

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

close #30