### PR TITLE
[Feat] Group 및 Chat 관련 API 수정 및 추가

### DIFF
--- a/src/modules/chat/chat.service.ts
+++ b/src/modules/chat/chat.service.ts
@@ -40,8 +40,9 @@ export class ChatService {
 		);
 
 		return {
-			chats,
-			nextCursor: chats.length > 0 ? chats[0].createdAt : null,
+			chats: chats.reverse(),
+			nextCursor:
+				chats.length > 0 ? chats[chats.length - 1].createdAt : null,
 		};
 	}
 

--- a/src/modules/chat/repository/chat.repository.ts
+++ b/src/modules/chat/repository/chat.repository.ts
@@ -28,7 +28,7 @@ export class ChatRepository {
 
 		return this.chatModel
 			.find(query)
-			.sort({ createdAt: 1 })
+			.sort({ createdAt: -1 })
 			.limit(take)
 			.populate([
 				{

--- a/src/modules/group/dto/group-query.dto.ts
+++ b/src/modules/group/dto/group-query.dto.ts
@@ -1,0 +1,45 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import {
+	IsBoolean,
+	IsNotEmpty,
+	IsNumber,
+	IsOptional,
+	IsString,
+} from 'class-validator';
+
+export class GroupQueryDto {
+	@ApiProperty({
+		description: '기준이 되는 Group의 ObjectId',
+		example: '65e8a5d6fc13ae5e7f000002',
+	})
+	@IsOptional()
+	@IsString()
+	cursor?: string;
+
+	@ApiProperty({
+		description: '불러올 항목 개수',
+		example: 10,
+	})
+	@IsNotEmpty()
+	@IsNumber()
+	@Transform(({ value }) => Number(value))
+	limit: number;
+
+	@ApiProperty({
+		description: '그룹 소속 여부',
+		example: true,
+	})
+	@IsNotEmpty()
+	@IsBoolean()
+	@Transform(({ value }) => Boolean(value))
+	is_mine: boolean;
+
+	@ApiProperty({
+		description: 'Group 제목 검색',
+		example: '서울',
+	})
+	@IsOptional()
+	@IsString()
+	name?: string;
+}

--- a/src/modules/group/dto/patch-respond-application.dto.ts
+++ b/src/modules/group/dto/patch-respond-application.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsNotEmpty } from 'class-validator';
+
+export class RespondApplicationDto {
+	@ApiProperty({
+		description: 'Group 가입 요청에 대한 수락 여부',
+		example: true,
+	})
+	@IsBoolean()
+	@IsNotEmpty()
+	accepted: boolean;
+}

--- a/src/modules/group/group-quizbook/dto/create-group-quizbook.dto.ts
+++ b/src/modules/group/group-quizbook/dto/create-group-quizbook.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
 import { IsDate, IsNotEmpty } from 'class-validator';
 
 export class CreateGroupQuizbookDto {
@@ -8,5 +9,6 @@ export class CreateGroupQuizbookDto {
 	})
 	@IsDate()
 	@IsNotEmpty()
+	@Type(() => Date)
 	endDate: Date;
 }

--- a/src/modules/group/group-quizbook/dto/group-quizbook-query.dto.ts
+++ b/src/modules/group/group-quizbook/dto/group-quizbook-query.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { IsBoolean, IsNotEmpty, IsNumber, IsString } from 'class-validator';
+
+export class GroupQuizbookQueryDto {
+	@ApiProperty({
+		description: '기준이 되는 Group 선정 문제집 마감일',
+		example: '2025-04-02',
+	})
+	@IsNotEmpty()
+	@IsString()
+	cursor: string;
+
+	@ApiProperty({
+		description: '불러올 항목 개수',
+		example: '2025-04-02',
+	})
+	@IsNotEmpty()
+	@IsNumber()
+	@Transform(({ value }) => Number(value))
+	limit: number;
+
+	@ApiProperty({
+		description: '마감일 완료 여부',
+		example: true,
+	})
+	@IsNotEmpty()
+	@IsBoolean()
+	@Transform(({ value }) => Boolean(value))
+	done: boolean;
+}

--- a/src/modules/group/group-quizbook/dto/group-quizbook-query.dto.ts
+++ b/src/modules/group/group-quizbook/dto/group-quizbook-query.dto.ts
@@ -13,7 +13,7 @@ export class GroupQuizbookQueryDto {
 
 	@ApiProperty({
 		description: '불러올 항목 개수',
-		example: '2025-04-02',
+		example: 10,
 	})
 	@IsNotEmpty()
 	@IsNumber()

--- a/src/modules/group/group-quizbook/group-quizbook.controller.ts
+++ b/src/modules/group/group-quizbook/group-quizbook.controller.ts
@@ -7,13 +7,15 @@ import {
 	Param,
 	Patch,
 	Post,
+	Query,
 } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { GroupQuizbookService } from './group-quizbook.service';
 import { ApiBaseResponse } from 'src/common/decorators/base-response.decorator';
 import { UserId } from 'src/common/decorators/user-id.decorator';
-import { GroupQuizbookExample } from './group-quizbook.example';
+import { GroupQuizbookListExample } from './group-quizbook.example';
 import { CreateGroupQuizbookDto } from './dto/create-group-quizbook.dto';
+import { GroupQuizbookQueryDto } from './dto/group-quizbook-query.dto';
 
 @Controller({ path: 'group/:groupId/quizbook', version: '1' })
 @ApiTags('GroupQuizbook')
@@ -25,12 +27,17 @@ export class GroupQuizbookController {
 		summary: 'Group의 선정 문제집 목록 조회',
 		description: 'Group의 선정 문제집 목록을 조회합니다.',
 	})
-	@ApiBaseResponse(HttpStatus.OK, '조회 성공', [GroupQuizbookExample])
-	getAllGroupQuizbook(
+	@ApiBaseResponse(HttpStatus.OK, '조회 성공', GroupQuizbookListExample)
+	getGroupQuizbookList(
 		@UserId() userId: string,
 		@Param('groupId') groupId: string,
+		@Query() query: GroupQuizbookQueryDto,
 	) {
-		return this.groupQuizbookService.getAllGroupQuizbook(userId, groupId);
+		return this.groupQuizbookService.getGroupQuizbookList(
+			userId,
+			groupId,
+			query,
+		);
 	}
 
 	@Post(':quizbookId')

--- a/src/modules/group/group-quizbook/group-quizbook.controller.ts
+++ b/src/modules/group/group-quizbook/group-quizbook.controller.ts
@@ -79,7 +79,7 @@ export class GroupQuizbookController {
 		description: 'Group 선정 문제집을 삭제합니다.',
 	})
 	@ApiBaseResponse(HttpStatus.OK, '삭제 성공')
-	async deleteGroupWithdraw(
+	async deleteGroupQuizbook(
 		@UserId() userId: string,
 		@Param('groupId') groupId: string,
 		@Param('quizbookId') quizbookId: string,

--- a/src/modules/group/group-quizbook/group-quizbook.example.ts
+++ b/src/modules/group/group-quizbook/group-quizbook.example.ts
@@ -18,6 +18,6 @@ export const GroupQuizbookListExample = {
 			endedAt: '2025-04-02',
 		},
 	],
-	nextCursor: '65e8a5d6fc13ae5e7f000002',
+	nextCursor: '2025-04-02',
 	leftCount: 24,
 };

--- a/src/modules/group/group-quizbook/group-quizbook.example.ts
+++ b/src/modules/group/group-quizbook/group-quizbook.example.ts
@@ -1,16 +1,23 @@
-export const GroupQuizbookExample = {
-	quizbook: {
-		_id: '65e8a5d6fc13ae5e7f000002',
-		title: '알고리즘 문제집',
-		description: '면접 준비용',
-		category: '알고리즘',
-		author: {
-			_id: '유저ID',
-			nickname: '유저 닉네임',
-			profileImg: '이미지 url',
+export const GroupQuizbookListExample = {
+	list: [
+		{
+			group: '65e8a5d6fc13ae5e7f000002',
+			quizbook: {
+				_id: '65e8a5d6fc13ae5e7f000002',
+				title: '알고리즘 문제집',
+				description: '면접 준비용',
+				category: '알고리즘',
+				author: {
+					_id: '유저ID',
+					nickname: '유저 닉네임',
+					profileImg: '이미지 url',
+				},
+				solvedCount: 100,
+				solvedRate: 85.5,
+			},
+			endedAt: '2025-04-02',
 		},
-		solvedCount: 100,
-		solvedRate: 85.5,
-	},
-	endedAt: '2025-04-02',
+	],
+	nextCursor: '65e8a5d6fc13ae5e7f000002',
+	leftCount: 24,
 };

--- a/src/modules/group/group-quizbook/group-quizbook.repository.ts
+++ b/src/modules/group/group-quizbook/group-quizbook.repository.ts
@@ -2,8 +2,13 @@ import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { GroupQuizbook } from './schema/group-quizbook.schema';
 import { DB_TYPE } from 'src/database/database.const';
-import { ClientSession, FilterQuery, Model } from 'mongoose';
+import { ClientSession, FilterQuery, Model, Types } from 'mongoose';
 import { toObjectId } from 'src/common/utils/database.util';
+
+interface GroupQuizbookListQuery {
+	group: Types.ObjectId;
+	endedAt?: { $lt: Date } | { $gt: Date };
+}
 
 @Injectable()
 export class GroupQuizbookRepository {
@@ -15,9 +20,24 @@ export class GroupQuizbookRepository {
 	/**
 	 * 특정 Group의 선정 문제집 카드 정보 목록 조회
 	 */
-	async findAllGroupQuizbook(groupId: string) {
+	async findGroupQuizbookList(
+		group: Types.ObjectId,
+		cursor: Date,
+		limit: number,
+		done: boolean,
+	) {
+		const query: GroupQuizbookListQuery = { group };
+
+		if (done) {
+			query.endedAt = { $lt: cursor };
+		} else {
+			query.endedAt = { $gt: cursor };
+		}
+
 		return this.groupQuizbookModel
-			.find({ group: toObjectId(groupId) })
+			.find(query)
+			.sort({ endedAt: done ? -1 : 1 })
+			.limit(limit)
 			.populate([
 				{
 					path: 'quizbook',
@@ -29,6 +49,21 @@ export class GroupQuizbookRepository {
 					},
 				},
 			]);
+	}
+
+	/**
+	 * 특정 Group의 선정 문제집 전체 개수 동기화를 위한 남은 개수 조회
+	 */
+	async findLeftCount(group: Types.ObjectId, cursor: Date, done: boolean) {
+		const query: GroupQuizbookListQuery = { group };
+
+		if (done) {
+			query.endedAt = { $lt: cursor };
+		} else {
+			query.endedAt = { $gt: cursor };
+		}
+
+		return this.groupQuizbookModel.countDocuments(query);
 	}
 
 	/**

--- a/src/modules/group/group-quizbook/group-quizbook.service.ts
+++ b/src/modules/group/group-quizbook/group-quizbook.service.ts
@@ -7,6 +7,7 @@ import { GroupQuizbookRepository } from './group-quizbook.repository';
 import { DatabaseService } from 'src/database/database.service';
 import { GroupRepository } from '../group.repository';
 import { toObjectId } from 'src/common/utils/database.util';
+import { GroupQuizbookQueryDto } from './dto/group-quizbook-query.dto';
 
 @Injectable()
 export class GroupQuizbookService {
@@ -16,7 +17,11 @@ export class GroupQuizbookService {
 		private readonly groupRepository: GroupRepository,
 	) {}
 
-	async getAllGroupQuizbook(userId: string, groupId: string) {
+	async getGroupQuizbookList(
+		userId: string,
+		groupId: string,
+		query: GroupQuizbookQueryDto,
+	) {
 		const group = await this.groupRepository.findById(groupId);
 
 		if (!group)
@@ -32,10 +37,30 @@ export class GroupQuizbookService {
 		if (indexOfNewOwner === -1)
 			throw new UnauthorizedException(`허가되지 않는 접근입니다.`);
 
-		const groupQuizbookList =
-			await this.groupQuizbookRepository.findAllGroupQuizbook(groupId);
+		const { cursor, limit, done } = query;
 
-		return groupQuizbookList;
+		const groupQuizbookList =
+			await this.groupQuizbookRepository.findGroupQuizbookList(
+				toObjectId(groupId),
+				new Date(cursor),
+				limit,
+				done,
+			);
+
+		const leftCount = await this.groupQuizbookRepository.findLeftCount(
+			toObjectId(groupId),
+			new Date(cursor),
+			done,
+		);
+
+		return {
+			list: groupQuizbookList,
+			nextCursor:
+				groupQuizbookList.length > 0
+					? groupQuizbookList[groupQuizbookList.length - 1].endedAt
+					: null,
+			leftCount: leftCount - groupQuizbookList.length,
+		};
 	}
 
 	async postCreateGroupQuizbook(

--- a/src/modules/group/group-quizbook/group-quizbook.service.ts
+++ b/src/modules/group/group-quizbook/group-quizbook.service.ts
@@ -80,11 +80,15 @@ export class GroupQuizbookService {
 			if (group.admin._id.toString() !== userId)
 				throw new UnauthorizedException(`허가되지 않는 접근입니다.`);
 
+			// endDate의 시간 부분을 23:59:59.999로 설정
+			const endedAt = new Date(endDate);
+			endedAt.setHours(23, 59, 59, 999);
+
 			// 그룹 선정 문제집 생성
 			const data = {
 				group: toObjectId(groupId),
 				quizbook: toObjectId(quizbookId),
-				endedAt: endDate,
+				endedAt,
 			};
 			const newGroupQuizbook = await this.groupQuizbookRepository.create(
 				data,
@@ -118,8 +122,12 @@ export class GroupQuizbookService {
 		if (group.admin._id.toString() !== userId)
 			throw new UnauthorizedException(`허가되지 않는 접근입니다.`);
 
+		// endDate의 시간 부분을 23:59:59.999로 설정
+		const endedAt = new Date(endDate);
+		endedAt.setHours(23, 59, 59, 999);
+
 		await this.groupQuizbookRepository.update(
-			{ endedAt: endDate },
+			{ endedAt },
 			groupId,
 			quizbookId,
 		);

--- a/src/modules/group/group.controller.ts
+++ b/src/modules/group/group.controller.ts
@@ -7,6 +7,7 @@ import {
 	Param,
 	Patch,
 	Post,
+	Query,
 } from '@nestjs/common';
 import { GroupService } from './group.service';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
@@ -22,20 +23,21 @@ import { CreateGroupDto } from './dto/create-group.dto';
 import { UpdateOwnerDto } from './dto/update-owner.dto';
 import { CreateGroupMemberDto } from './dto/create-group-member.dto';
 import { RespondApplicationDto } from './dto/patch-respond-application.dto';
+import { GroupQueryDto } from './dto/group-query.dto';
 
 @Controller({ path: 'group', version: '1' })
 @ApiTags('Group')
 export class GroupController {
 	constructor(private readonly groupService: GroupService) {}
 
-	@Get('me')
+	@Get()
 	@ApiOperation({
-		summary: '내가 속한 Group 목록 조회',
-		description: '내가 속한 Group 목록을 조회합니다.',
+		summary: 'Group 목록 조회',
+		description: 'Group 목록을 조회합니다.',
 	})
 	@ApiBaseResponse(HttpStatus.OK, '조회 성공', GroupListExample)
-	getAllBelongedGroup(@UserId() userId: string) {
-		return this.groupService.getAllBelongedGroup(userId);
+	getGroupList(@UserId() userId: string, @Query() query: GroupQueryDto) {
+		return this.groupService.getGroupList(userId, query);
 	}
 
 	@Get(':groupId')

--- a/src/modules/group/group.controller.ts
+++ b/src/modules/group/group.controller.ts
@@ -84,6 +84,19 @@ export class GroupController {
 		await this.groupService.deleteGroup(userId, groupId);
 	}
 
+	@Patch(':groupId/application')
+	@ApiOperation({
+		summary: 'Group 가입 요청',
+		description: 'Group 가입을 요청합니다.',
+	})
+	@ApiBaseResponse(HttpStatus.OK, '요청 성공')
+	async patchGroupApplying(
+		@UserId() userId: string,
+		@Param('groupId') groupId: string,
+	) {
+		await this.groupService.patchGroupApplying(userId, groupId);
+	}
+
 	@Get(':groupId/invitation')
 	@ApiOperation({
 		summary: 'Group 초대 링크 조회',

--- a/src/modules/group/group.controller.ts
+++ b/src/modules/group/group.controller.ts
@@ -12,10 +12,10 @@ import { GroupService } from './group.service';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { ApiBaseResponse } from 'src/common/decorators/base-response.decorator';
 import {
-	allBelongedGroupExample,
 	GroupIdExample,
 	GroupInfoExample,
 	GroupInviteUrlExample,
+	GroupListExample,
 } from './group.example';
 import { UserId } from 'src/common/decorators/user-id.decorator';
 import { CreateGroupDto } from './dto/create-group.dto';
@@ -33,7 +33,7 @@ export class GroupController {
 		summary: '내가 속한 Group 목록 조회',
 		description: '내가 속한 Group 목록을 조회합니다.',
 	})
-	@ApiBaseResponse(HttpStatus.OK, '조회 성공', [allBelongedGroupExample])
+	@ApiBaseResponse(HttpStatus.OK, '조회 성공', GroupListExample)
 	getAllBelongedGroup(@UserId() userId: string) {
 		return this.groupService.getAllBelongedGroup(userId);
 	}

--- a/src/modules/group/group.controller.ts
+++ b/src/modules/group/group.controller.ts
@@ -21,6 +21,7 @@ import { UserId } from 'src/common/decorators/user-id.decorator';
 import { CreateGroupDto } from './dto/create-group.dto';
 import { UpdateOwnerDto } from './dto/update-owner.dto';
 import { CreateGroupMemberDto } from './dto/create-group-member.dto';
+import { RespondApplicationDto } from './dto/patch-respond-application.dto';
 
 @Controller({ path: 'group', version: '1' })
 @ApiTags('Group')
@@ -95,6 +96,24 @@ export class GroupController {
 		@Param('groupId') groupId: string,
 	) {
 		await this.groupService.patchGroupApplying(userId, groupId);
+	}
+
+	@Patch(':groupId/application-response')
+	@ApiOperation({
+		summary: 'Group 가입 요청 처리(수락 또는 거절)',
+		description: 'Group 가입 요청을 수락 또는 거절 처리합니다.',
+	})
+	@ApiBaseResponse(HttpStatus.OK, '처리 성공')
+	async patchRespondToApplication(
+		@UserId() userId: string,
+		@Param('groupId') groupId: string,
+		@Body() request: RespondApplicationDto,
+	) {
+		await this.groupService.patchRespondToApplication(
+			userId,
+			groupId,
+			request.accepted,
+		);
 	}
 
 	@Get(':groupId/invitation')

--- a/src/modules/group/group.example.ts
+++ b/src/modules/group/group.example.ts
@@ -3,6 +3,7 @@ export const allBelongedGroupExample = {
 	name: '서울 강남 cs 공부 스터디',
 	description: '서울에 사는 컴공 취준생들의 cs 공부 스터디 그룹입니다.',
 	admin: {},
+	'chatRoom?': '65e8a5d6fc13ae5e7f000002',
 	memberCount: '7',
 };
 
@@ -12,6 +13,7 @@ export const GroupInfoExample = {
 	description: '서울에 사는 컴공 취준생들의 cs 공부 스터디 그룹입니다.',
 	admin: {},
 	memberList: [{}],
+	applyingUserList: [{}],
 	chatRoom: '65e8a5d6fc13ae5e7f000002',
 	createdAt: '2025-03-30',
 };

--- a/src/modules/group/group.example.ts
+++ b/src/modules/group/group.example.ts
@@ -1,10 +1,17 @@
-export const allBelongedGroupExample = {
-	_id: '65e8a5d6fc13ae5e7f000002',
-	name: '서울 강남 cs 공부 스터디',
-	description: '서울에 사는 컴공 취준생들의 cs 공부 스터디 그룹입니다.',
-	admin: {},
-	'chatRoom?': '65e8a5d6fc13ae5e7f000002',
-	memberCount: '7',
+export const GroupListExample = {
+	list: [
+		{
+			_id: '65e8a5d6fc13ae5e7f000002',
+			name: '서울 강남 cs 공부 스터디',
+			description:
+				'서울에 사는 컴공 취준생들의 cs 공부 스터디 그룹입니다.',
+			admin: {},
+			'chatRoom?': '65e8a5d6fc13ae5e7f000002',
+			memberCount: '7',
+		},
+	],
+	nextCursor: '65e8a5d6fc13ae5e7f000002',
+	leftCount: 24,
 };
 
 export const GroupInfoExample = {

--- a/src/modules/group/group.example.ts
+++ b/src/modules/group/group.example.ts
@@ -6,8 +6,9 @@ export const GroupListExample = {
 			description:
 				'서울에 사는 컴공 취준생들의 cs 공부 스터디 그룹입니다.',
 			admin: {},
-			'chatRoom?': '65e8a5d6fc13ae5e7f000002',
+			chatRoom: '65e8a5d6fc13ae5e7f000002',
 			memberCount: '7',
+			is_mine: true,
 		},
 	],
 	nextCursor: '65e8a5d6fc13ae5e7f000002',

--- a/src/modules/group/group.example.ts
+++ b/src/modules/group/group.example.ts
@@ -4,7 +4,6 @@ export const allBelongedGroupExample = {
 	description: '서울에 사는 컴공 취준생들의 cs 공부 스터디 그룹입니다.',
 	admin: {},
 	memberCount: '7',
-	imminentQuizbook: {},
 };
 
 export const GroupInfoExample = {
@@ -13,7 +12,6 @@ export const GroupInfoExample = {
 	description: '서울에 사는 컴공 취준생들의 cs 공부 스터디 그룹입니다.',
 	admin: {},
 	memberList: [{}],
-	imminentQuizbook: {},
 	chatRoom: '65e8a5d6fc13ae5e7f000002',
 	createdAt: '2025-03-30',
 };

--- a/src/modules/group/group.module.ts
+++ b/src/modules/group/group.module.ts
@@ -6,7 +6,6 @@ import { Group, GroupSchema } from './schema/group.schema';
 import { DB_TYPE } from 'src/database/database.const';
 import { GroupRepository } from './group.repository';
 import { DatabaseModule } from 'src/database/database.module';
-import { QuizbookModule } from '../quizbook/quizbook.module';
 import { AuthTokenModule } from '../auth/auth-token/auth-token.module';
 import { GroupQuizbookModule } from './group-quizbook/group-quizbook.module';
 import { ChatModule } from '../chat/chat.module';
@@ -18,7 +17,6 @@ import { ChatModule } from '../chat/chat.module';
 			DB_TYPE.DEFAULT,
 		),
 		DatabaseModule,
-		QuizbookModule,
 		AuthTokenModule,
 		GroupQuizbookModule,
 		ChatModule,

--- a/src/modules/group/group.repository.ts
+++ b/src/modules/group/group.repository.ts
@@ -1,9 +1,16 @@
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Group } from './schema/group.schema';
-import { ClientSession, FilterQuery, Model } from 'mongoose';
+import { ClientSession, FilterQuery, Model, Types } from 'mongoose';
 import { DB_TYPE } from 'src/database/database.const';
+import { GroupQueryDto } from './dto/group-query.dto';
 import { toObjectId } from 'src/common/utils/database.util';
+
+interface GroupQuery {
+	cursor?: { $lt: Types.ObjectId };
+	memberList?: Types.ObjectId;
+	name?: { $regex: string; $options: string };
+}
 
 @Injectable()
 export class GroupRepository {
@@ -13,11 +20,21 @@ export class GroupRepository {
 	) {}
 
 	/**
-	 * 내가 속한 Group 목록 조회
+	 * Group 목록 조회
 	 */
-	async findAllBelongedGroupById(memberId: string) {
+	async findGroupList(memberId: Types.ObjectId, query: GroupQueryDto) {
+		const { cursor, limit, is_mine, name } = query;
+
+		const filter: GroupQuery = {};
+
+		if (cursor) filter.cursor = { $lt: toObjectId(cursor) };
+		if (is_mine) filter.memberList = memberId;
+		if (name) filter.name = { $regex: name, $options: 'i' };
+
 		return this.groupModel
-			.find({ memberList: toObjectId(memberId) })
+			.find(filter)
+			.sort({ _id: -1 })
+			.limit(limit)
 			.populate([
 				{
 					path: 'admin',
@@ -25,6 +42,21 @@ export class GroupRepository {
 					select: 'nickname profileImg',
 				},
 			]);
+	}
+
+	/**
+	 * Group 전체 개수 동기화를 위한 남은 개수 조회
+	 */
+	async findLeftCount(memberId: Types.ObjectId, query: GroupQueryDto) {
+		const { cursor, is_mine, name } = query;
+
+		const filter: GroupQuery = {};
+
+		if (cursor) filter.cursor = { $lt: toObjectId(cursor) };
+		if (is_mine) filter.memberList = memberId;
+		if (name) filter.name = { $regex: name, $options: 'i' };
+
+		return this.groupModel.countDocuments(filter);
 	}
 
 	/**

--- a/src/modules/group/group.repository.ts
+++ b/src/modules/group/group.repository.ts
@@ -24,11 +24,6 @@ export class GroupRepository {
 					model: 'User',
 					select: 'nickname profileImg',
 				},
-				{
-					path: 'groupQuizbookList',
-					model: 'GroupQuizbook',
-					select: 'quizbook endedAt',
-				},
 			]);
 	}
 
@@ -46,11 +41,6 @@ export class GroupRepository {
 				path: 'memberList',
 				model: 'User',
 				select: 'nickname profileImg email',
-			},
-			{
-				path: 'groupQuizbookList',
-				model: 'GroupQuizbook',
-				select: 'quizbook endedAt',
 			},
 		]);
 	}

--- a/src/modules/group/group.repository.ts
+++ b/src/modules/group/group.repository.ts
@@ -42,6 +42,11 @@ export class GroupRepository {
 				model: 'User',
 				select: 'nickname profileImg email',
 			},
+			{
+				path: 'applyingUserList',
+				model: 'User',
+				select: 'nickname profileImg email',
+			},
 		]);
 	}
 

--- a/src/modules/group/group.service.ts
+++ b/src/modules/group/group.service.ts
@@ -35,10 +35,18 @@ export class GroupService {
 		// 그룹 정보를 변환
 		const transformedGroups = await Promise.all(
 			groupList.map((group) => {
-				const { memberList, createdAt, updatedAt, ...filteredFields } =
-					group.toObject();
+				const {
+					memberList,
+					applyingUserList,
+					groupQuizbookList,
+					createdAt,
+					updatedAt,
+					...filteredFields
+				} = group.toObject();
 
 				// 간단히 변수 사용 처리
+				void applyingUserList;
+				void groupQuizbookList;
 				void createdAt;
 				void updatedAt;
 
@@ -63,8 +71,10 @@ export class GroupService {
 				`해당 ${groupId} Group을 찾을 수 없습니다.`,
 			);
 
-		const { memberList, updatedAt, ...filteredFields } = group.toObject();
+		const { memberList, groupQuizbookList, updatedAt, ...filteredFields } =
+			group.toObject();
 
+		void groupQuizbookList;
 		void updatedAt;
 
 		if (!memberList.map((user) => user._id.toString()).includes(userId))

--- a/src/modules/group/group.service.ts
+++ b/src/modules/group/group.service.ts
@@ -202,6 +202,32 @@ export class GroupService {
 		});
 	}
 
+	async patchGroupApplying(userId: string, groupId: string) {
+		const group = await this.groupRepository.findById(groupId);
+
+		if (!group)
+			throw new NotFoundException(
+				`해당 ${groupId} Group을 찾을 수 없습니다.`,
+			);
+
+		const targetMemberList = group.memberList.map((user) =>
+			user._id.toString(),
+		);
+		const indexOfNewOwner = targetMemberList.indexOf(userId);
+
+		if (indexOfNewOwner !== -1)
+			throw new UnauthorizedException(
+				`해당 ${userId} 사용자는 이미 그룹에 소속되어 있습니다.`,
+			);
+
+		await this.groupRepository.update(
+			{
+				$addToSet: { applyingUserList: userId }, // 중복 없이 배열에 userId 추가
+			},
+			groupId,
+		);
+	}
+
 	async getInviteUrl(userId: string, groupId: string) {
 		const group = await this.groupRepository.findById(groupId);
 

--- a/src/modules/group/group.service.ts
+++ b/src/modules/group/group.service.ts
@@ -222,10 +222,46 @@ export class GroupService {
 
 		await this.groupRepository.update(
 			{
-				$addToSet: { applyingUserList: userId }, // 중복 없이 배열에 userId 추가
+				$addToSet: { applyingUserList: userId },
 			},
 			groupId,
 		);
+	}
+
+	async patchRespondToApplication(
+		userId: string,
+		groupId: string,
+		accepted: boolean,
+	) {
+		const group = await this.groupRepository.findById(groupId);
+
+		if (!group)
+			throw new NotFoundException(
+				`해당 ${groupId} Group을 찾을 수 없습니다.`,
+			);
+
+		const targetApplyingUserList = group.applyingUserList.map((user) =>
+			user._id.toString(),
+		);
+		const indexOfApplyingUser = targetApplyingUserList.indexOf(userId);
+
+		if (indexOfApplyingUser === -1)
+			throw new NotFoundException(
+				`해당 ${userId} 사용자는 그룹에 가입 요청을 하지 않았습니다.`,
+			);
+
+		let filter: FilterQuery<Group>;
+		if (accepted) {
+			filter = {
+				$pull: { applyingUserList: userId },
+				$addToSet: { memberList: userId },
+			};
+		} else {
+			filter = {
+				$pull: { applyingUserList: userId },
+			};
+		}
+		await this.groupRepository.update(filter, groupId);
 	}
 
 	async getInviteUrl(userId: string, groupId: string) {

--- a/src/modules/group/group.service.ts
+++ b/src/modules/group/group.service.ts
@@ -4,8 +4,6 @@ import {
 	UnauthorizedException,
 } from '@nestjs/common';
 import { GroupRepository } from './group.repository';
-import { QuizbookRepository } from '../quizbook/quizbook.repository';
-import { GroupQuizbook } from './group-quizbook/schema/group-quizbook.schema';
 import { toObjectId } from 'src/common/utils/database.util';
 import { FilterQuery, Types } from 'mongoose';
 import { CreateGroupDto } from './dto/create-group.dto';
@@ -14,7 +12,6 @@ import { Group } from './schema/group.schema';
 import { AuthTokenService } from '../auth/auth-token/auth-token.service';
 import { TokenType } from '../auth/auth-token/auth-token.types';
 import { InviteTokenPayloadDto } from './dto/invite-token-payload.dto';
-import { Quizbook } from '../quizbook/schema/quizbook.schema';
 import { GroupQuizbookRepository } from './group-quizbook/group-quizbook.repository';
 import { ChatRoomRepository } from '../chat/repository/chat-room.repository';
 import { ReadStatusRepository } from '../chat/repository/read-status.repository';
@@ -24,7 +21,6 @@ import { ChatRoomType } from '../chat/schema/chat-room.schema';
 export class GroupService {
 	constructor(
 		private readonly groupRepository: GroupRepository,
-		private readonly quizbookRepository: QuizbookRepository,
 		private readonly databaseService: DatabaseService,
 		private readonly authTokenService: AuthTokenService,
 		private readonly groupQuizbookRepository: GroupQuizbookRepository,
@@ -32,58 +28,15 @@ export class GroupService {
 		private readonly readStatusRepository: ReadStatusRepository,
 	) {}
 
-	async makeImminentQuizbook(
-		groupQuizbookList: Types.ObjectId[] | GroupQuizbook[],
-	) {
-		// imminentQuizbook 계산: endedAt이 오늘 이후인 문제집 중 가장 가까운 날짜를 찾음
-		const today = new Date();
-		const year = today.getFullYear();
-		const month = String(today.getMonth() + 1).padStart(2, '0'); // 월은 0부터 시작하므로 +1
-		const day = String(today.getDate()).padStart(2, '0');
-		const todayDate = new Date(`${year}-${month}-${day}`);
-		const quizbookList = groupQuizbookList
-			.filter((quizbook: GroupQuizbook) => quizbook.endedAt >= todayDate) // 오늘 이후만 포함
-			.sort(
-				(a: GroupQuizbook, b: GroupQuizbook) =>
-					new Date(a.endedAt).getTime() -
-					new Date(b.endedAt).getTime(),
-			) as GroupQuizbook[];
-
-		let result: { endedAt?: Date } & Partial<Quizbook> = {};
-
-		if (quizbookList.length !== 0) {
-			const targetId = quizbookList[0].quizbook.toString();
-			const targetQuizbook =
-				await this.quizbookRepository.findById(targetId);
-
-			if (!targetQuizbook)
-				throw new NotFoundException(
-					`해당 ${targetId} Quizbook을 찾을 수 없습니다.`,
-				);
-
-			result = {
-				...targetQuizbook.toObject(),
-				endedAt: quizbookList[0].endedAt,
-			};
-		}
-
-		return result;
-	}
-
 	async getAllBelongedGroup(userId: string) {
 		const groupList =
 			await this.groupRepository.findAllBelongedGroupById(userId);
 
 		// 그룹 정보를 변환
 		const transformedGroups = await Promise.all(
-			groupList.map(async (group) => {
-				const {
-					memberList,
-					groupQuizbookList,
-					createdAt,
-					updatedAt,
-					...filteredFields
-				} = group.toObject();
+			groupList.map((group) => {
+				const { memberList, createdAt, updatedAt, ...filteredFields } =
+					group.toObject();
 
 				// 간단히 변수 사용 처리
 				void createdAt;
@@ -92,13 +45,9 @@ export class GroupService {
 				// memberCount 계산
 				const memberCount = memberList.length;
 
-				const imminentQuizbook =
-					await this.makeImminentQuizbook(groupQuizbookList);
-
 				return {
 					...filteredFields,
 					memberCount,
-					imminentQuizbook,
 				};
 			}),
 		);
@@ -114,21 +63,16 @@ export class GroupService {
 				`해당 ${groupId} Group을 찾을 수 없습니다.`,
 			);
 
-		const { memberList, groupQuizbookList, updatedAt, ...filteredFields } =
-			group.toObject();
+		const { memberList, updatedAt, ...filteredFields } = group.toObject();
 
 		void updatedAt;
 
 		if (!memberList.map((user) => user._id.toString()).includes(userId))
 			throw new UnauthorizedException(`허가되지 않는 접근입니다.`);
 
-		const imminentQuizbook =
-			await this.makeImminentQuizbook(groupQuizbookList);
-
 		return {
 			...filteredFields,
 			memberList,
-			imminentQuizbook,
 		};
 	}
 
@@ -212,7 +156,7 @@ export class GroupService {
 				group.groupQuizbookList.map(async (groupQuizbook) => {
 					const deletedGroupQuizbook =
 						await this.groupQuizbookRepository.deleteById(
-							groupQuizbook._id.toString(),
+							groupQuizbook.toString(),
 							session,
 						);
 

--- a/src/modules/group/group.service.ts
+++ b/src/modules/group/group.service.ts
@@ -16,6 +16,7 @@ import { GroupQuizbookRepository } from './group-quizbook/group-quizbook.reposit
 import { ChatRoomRepository } from '../chat/repository/chat-room.repository';
 import { ReadStatusRepository } from '../chat/repository/read-status.repository';
 import { ChatRoomType } from '../chat/schema/chat-room.schema';
+import { GroupQueryDto } from './dto/group-query.dto';
 
 @Injectable()
 export class GroupService {
@@ -28,39 +29,56 @@ export class GroupService {
 		private readonly readStatusRepository: ReadStatusRepository,
 	) {}
 
-	async getAllBelongedGroup(userId: string) {
-		const groupList =
-			await this.groupRepository.findAllBelongedGroupById(userId);
-
-		// 그룹 정보를 변환
-		const transformedGroups = await Promise.all(
-			groupList.map((group) => {
-				const {
-					memberList,
-					applyingUserList,
-					groupQuizbookList,
-					createdAt,
-					updatedAt,
-					...filteredFields
-				} = group.toObject();
-
-				// 간단히 변수 사용 처리
-				void applyingUserList;
-				void groupQuizbookList;
-				void createdAt;
-				void updatedAt;
-
-				// memberCount 계산
-				const memberCount = memberList.length;
-
-				return {
-					...filteredFields,
-					memberCount,
-				};
-			}),
+	async getGroupList(userId: string, query: GroupQueryDto) {
+		const groupList = await this.groupRepository.findGroupList(
+			toObjectId(userId),
+			query,
 		);
 
-		return transformedGroups;
+		const leftCount = await this.groupRepository.findLeftCount(
+			toObjectId(userId),
+			query,
+		);
+
+		// 그룹 정보를 변환
+		const transformedGroups = groupList.map((group) => {
+			const {
+				memberList,
+				applyingUserList,
+				groupQuizbookList,
+				createdAt,
+				updatedAt,
+				...filteredFields
+			} = group.toObject();
+
+			// 간단히 변수 사용 처리
+			void applyingUserList;
+			void groupQuizbookList;
+			void createdAt;
+			void updatedAt;
+
+			// memberCount 계산
+			const memberCount = memberList.length;
+
+			// 소속 여부
+			const targetMemberList = memberList.map((user) => user.toString());
+			const indexOfUser = targetMemberList.indexOf(userId);
+
+			return {
+				...filteredFields,
+				memberCount,
+				is_mine: indexOfUser !== -1,
+			};
+		});
+
+		return {
+			list: transformedGroups,
+			nextCursor:
+				transformedGroups.length > 0
+					? transformedGroups[transformedGroups.length - 1]._id
+					: null,
+			leftCount: leftCount - transformedGroups.length,
+		};
 	}
 
 	async getGroupInfo(userId: string, groupId: string) {

--- a/src/modules/group/schema/group.schema.ts
+++ b/src/modules/group/schema/group.schema.ts
@@ -19,6 +19,12 @@ export class Group extends Document {
 	memberList: Types.ObjectId[];
 
 	@Prop({
+		type: [{ type: Types.ObjectId, ref: 'User' }],
+		default: [],
+	})
+	applyingUserList: Types.ObjectId[];
+
+	@Prop({
 		type: [{ type: Types.ObjectId, ref: 'GroupQuizbook' }],
 		default: [],
 	})


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

Group 및 Chat 관련 API를 수정하고, 그룹 가입 관련 API를 추가합니다.

## 📌 이슈 넘버

- #39 

## 📝 작업 내용

### 수정
- 나의 그룹 목록 조회 api를 그룹 조회 api로 확장 및 cursor based pagination 적용
- 그룹의 선정 문제집 목록 조회 api에 cursor based pagination 적용
- Group Repository 수정 및 관련 api Response 수정
- 채팅 내역 조회 api 정렬 순서 변경

### 추가
- Group 스키마 applyingUserList Prop 추가
- 그룹 가입 요청 api
- 그룹 가입 요청 처리(수락 또는 거절) api
- Swagger api 문서화 작업 ([API 명세](https://api.quizbank.store/))

## 💬 문제 발생

 cursor based pagination을 적용한 api의 반환값 중 하나인 totalCount(조회 가능한 데이터 총 개수)가 여러 사용자의 상호작용(중간에 데이터 삭제, 수정, 추가)으로 인해 프론트엔드 무한스크롤에 랜더링된 데이터 개수(모든 데이터가 불러졌을 경우)와 일치하지 못할 수 있다는 예외를 생각해보았고 totalCount에 대한 고민이 생겼습니다.

## :rocket: 해결
- api에서 totalCount를 반환하지 않고 앞으로 조회 가능한 남은 데이터의 개수를 의미하는 leftCount를 반환하도록 수정하였습니다. 이로 인해 프론트엔드쪽에서 "이미 랜더링된 데이터 개수 + leftCount"로 조회 가능한 데이터 총 개수를 계산할 수 있게 되고 모든 데이터들이 랜더링 되었을 때, 전체 데이터 개수와 일치하게 됩니다.

close #39 
