### PR TITLE
[Fix] Group, ReadStatus Repository 수정

### DIFF
--- a/src/modules/chat/repository/read-status.repository.ts
+++ b/src/modules/chat/repository/read-status.repository.ts
@@ -64,9 +64,13 @@ export class ReadStatusRepository {
 	/**
 	 * 특정 그룹원의 ReadStatus 삭제
 	 */
-	async delete(userId: Types.ObjectId, session?: ClientSession) {
+	async delete(
+		userId: Types.ObjectId,
+		chatRoomId: Types.ObjectId,
+		session?: ClientSession,
+	) {
 		return this.readStatusModel.findOneAndDelete(
-			{ member: userId },
+			{ member: userId, chatRoom: chatRoomId },
 			{ session },
 		);
 	}

--- a/src/modules/group/group.module.ts
+++ b/src/modules/group/group.module.ts
@@ -1,4 +1,4 @@
-import { forwardRef, Module } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { GroupService } from './group.service';
 import { GroupController } from './group.controller';
 import { MongooseModule } from '@nestjs/mongoose';
@@ -9,7 +9,6 @@ import { DatabaseModule } from 'src/database/database.module';
 import { AuthTokenModule } from '../auth/auth-token/auth-token.module';
 import { GroupQuizbookModule } from './group-quizbook/group-quizbook.module';
 import { ChatModule } from '../chat/chat.module';
-import { QuizbookModule } from '../quizbook/quizbook.module';
 
 @Module({
 	imports: [
@@ -18,7 +17,6 @@ import { QuizbookModule } from '../quizbook/quizbook.module';
 			DB_TYPE.DEFAULT,
 		),
 		DatabaseModule,
-		forwardRef(() => QuizbookModule),
 		AuthTokenModule,
 		GroupQuizbookModule,
 		ChatModule,

--- a/src/modules/group/group.repository.ts
+++ b/src/modules/group/group.repository.ts
@@ -8,7 +8,7 @@ import { toObjectId } from 'src/common/utils/database.util';
 
 interface GroupQuery {
 	cursor?: { $lt: Types.ObjectId };
-	memberList?: Types.ObjectId;
+	memberList?: { $in: [Types.ObjectId] };
 	name?: { $regex: string; $options: string };
 }
 
@@ -28,7 +28,7 @@ export class GroupRepository {
 		const filter: GroupQuery = {};
 
 		if (cursor) filter.cursor = { $lt: toObjectId(cursor) };
-		if (is_mine) filter.memberList = memberId;
+		if (is_mine) filter.memberList = { $in: [memberId] };
 		if (name) filter.name = { $regex: name, $options: 'i' };
 
 		return this.groupModel
@@ -53,7 +53,7 @@ export class GroupRepository {
 		const filter: GroupQuery = {};
 
 		if (cursor) filter.cursor = { $lt: toObjectId(cursor) };
-		if (is_mine) filter.memberList = memberId;
+		if (is_mine) filter.memberList = { $in: [memberId] };
 		if (name) filter.name = { $regex: name, $options: 'i' };
 
 		return this.groupModel.countDocuments(filter);

--- a/src/modules/group/group.service.ts
+++ b/src/modules/group/group.service.ts
@@ -436,6 +436,7 @@ export class GroupService {
 			// 해당 유저의 ReadStatus 삭제
 			const deletedReadStatus = await this.readStatusRepository.delete(
 				toObjectId(userId),
+				group.chatRoom,
 				session,
 			);
 			if (!deletedReadStatus)
@@ -475,6 +476,7 @@ export class GroupService {
 			// 해당 유저의 ReadStatus 삭제
 			const deletedReadStatus = await this.readStatusRepository.delete(
 				toObjectId(memberId),
+				group.chatRoom,
 				session,
 			);
 			if (!deletedReadStatus)


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

Group과 ReadStatus Repository의 mongoose 메소드에서 사용되는 쿼리가 원하는 방식으로 작동되지 않는 것을 확인하고 수정하였습니다.

## 📌 이슈 넘버

- #39 

## 📝 작업 내용

- Group 조회 시 memberList 조건에서 $in으로 사용자 포함 여부 정확히 검사
- 특정 그룹원의 ReadStatus 삭제를 위한 조건 추가

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

close #39 
