### PR TITLE
[Feat] AI 연동 채점 기능 개발

### DIFF
--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -65,6 +65,10 @@ jobs:
                             secret: OAUTH_GITHUB_CLIENT_ID
                           - name: OAUTH_GITHUB_CLIENT_SECRET
                             secret: OAUTH_GITHUB_CLIENT_SECRET
+                          - name: GEMINI_API_URL
+                            secret: GEMINI_API_URL
+                          - name: GEMINI_API_KEY
+                            secret: GEMINI_API_KEY
                         ports: 3000
                         build: pnpm build
                         start: pnpm start:prod

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"@nestjs/platform-socket.io": "^11.0.11",
 		"@nestjs/swagger": "^11.0.6",
 		"@nestjs/websockets": "^11.0.11",
+		"axios": "^1.8.4",
 		"bcrypt": "^5.1.1",
 		"cache-manager": "^6.4.1",
 		"class-transformer": "^0.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@nestjs/websockets':
         specifier: ^11.0.11
         version: 11.0.12(@nestjs/common@11.0.12(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.0.12)(@nestjs/platform-socket.io@11.0.12)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      axios:
+        specifier: ^1.8.4
+        version: 1.8.4
       bcrypt:
         specifier: ^5.1.1
         version: 5.1.1
@@ -1930,6 +1933,9 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  axios@1.8.4:
+    resolution: {integrity: sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==}
+
   b4a@1.6.7:
     resolution: {integrity: sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==}
 
@@ -2680,6 +2686,15 @@ packages:
 
   fn.name@1.1.0:
     resolution: {integrity: sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==}
+
+  follow-redirects@1.15.9:
+    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
 
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
@@ -3760,6 +3775,9 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -6899,6 +6917,14 @@ snapshots:
 
   asynckit@0.4.0: {}
 
+  axios@1.8.4:
+    dependencies:
+      follow-redirects: 1.15.9
+      form-data: 4.0.2
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
   b4a@1.6.7: {}
 
   babel-jest@29.7.0(@babel/core@7.26.10):
@@ -7703,6 +7729,8 @@ snapshots:
   flatted@3.3.3: {}
 
   fn.name@1.1.0: {}
+
+  follow-redirects@1.15.9: {}
 
   foreground-child@3.3.1:
     dependencies:
@@ -8896,6 +8924,8 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -22,6 +22,7 @@ import { UploadModule } from './modules/upload/upload.module';
 import { CategoryModule } from './modules/category/category.module';
 import { FollowModule } from './modules/follow/follow.module';
 import { ChatModule } from './modules/chat/chat.module';
+import { AIModule } from './modules/ai/ai.module';
 
 @Module({
 	imports: [
@@ -44,6 +45,7 @@ import { ChatModule } from './modules/chat/chat.module';
 		CategoryModule,
 		FollowModule,
 		ChatModule,
+		AIModule,
 	],
 	providers: [
 		{

--- a/src/config/env.const.ts
+++ b/src/config/env.const.ts
@@ -35,4 +35,10 @@ export const envKeys = {
 			SECRET: 'OAUTH_GITHUB_CLIENT_SECRET',
 		},
 	},
+	AI: {
+		GEMINI: {
+			KEY: 'GEMINI_API_KEY',
+			URL: 'GEMINI_API_URL',
+		},
+	},
 };

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -23,4 +23,6 @@ export const envValidationSchema = Joi.object({
 	CLOUDFLARE_R2_PUBLIC_URL: Joi.string(),
 	GITHUB_CLIENT_ID: Joi.string(),
 	GITHUB_CLIENT_SECRET: Joi.string(),
+	GEMINI_API_URL: Joi.string(),
+	GEMINI_API_KEY: Joi.string(),
 });

--- a/src/modules/ai/ai.module.ts
+++ b/src/modules/ai/ai.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { AIService } from './ai.service';
+import { GeminiClient } from './client/gemini-client';
+
+@Module({
+	providers: [GeminiClient, AIService],
+	exports: [AIService],
+})
+export class AIModule {}

--- a/src/modules/ai/ai.service.ts
+++ b/src/modules/ai/ai.service.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@nestjs/common';
+import { CategoryType } from '../quizbook/schema/quizbook.schema';
+import { generateModelAnswerPrompt } from './prompt/modelAnswer.prompt';
+import { Quiz, QuizType } from '../quiz/schema/quiz.schema';
+import { generateShortAnswerPrompt } from './prompt/shortAnswer.prompt';
+import { generateLongAnswerPrompt } from './prompt/longAnswer.prompt';
+import { GeminiClient } from './client/gemini-client';
+import { cleanRefinedAnswer, getEnglishCategory } from './utils/ai.utils';
+
+@Injectable()
+export class AIService {
+	constructor(private readonly geminiClient: GeminiClient) {}
+
+	async checkModelAnswerWithAI(
+		category: CategoryType,
+		question: string,
+		answer: string,
+	) {
+		const prompt = generateModelAnswerPrompt(
+			getEnglishCategory(category),
+			question,
+			answer,
+		);
+
+		const res = await this.geminiClient.request(prompt);
+
+		const model = cleanRefinedAnswer(res);
+
+		return model;
+	}
+
+	async gradeWithAI(quiz: Quiz, category: CategoryType, answer: string) {
+		const prompt =
+			quiz.type === QuizType.SHORT_ANSWER
+				? generateShortAnswerPrompt(
+						category,
+						quiz.question,
+						quiz.answer,
+						answer,
+					)
+				: generateLongAnswerPrompt(
+						category,
+						quiz.question,
+						quiz.answer,
+						answer,
+					);
+
+		const res = await this.geminiClient.request(prompt);
+
+		const score = Number(cleanRefinedAnswer(res));
+
+		return score;
+	}
+}

--- a/src/modules/ai/ai.types.ts
+++ b/src/modules/ai/ai.types.ts
@@ -1,0 +1,16 @@
+export interface GeminiCandidatePart {
+	text: string;
+}
+
+export interface GeminiContent {
+	parts: GeminiCandidatePart[];
+}
+
+export interface GeminiCandidate {
+	content: GeminiContent;
+	finishReason: string;
+}
+
+export interface GeminiResponse {
+	candidates: GeminiCandidate[];
+}

--- a/src/modules/ai/client/gemini-client.ts
+++ b/src/modules/ai/client/gemini-client.ts
@@ -1,0 +1,27 @@
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import axios from 'axios';
+import { envKeys } from 'src/config/env.const';
+import { GeminiResponse } from '../ai.types';
+
+@Injectable()
+export class GeminiClient {
+	constructor(private readonly configService: ConfigService) {}
+
+	async request(prompt: string) {
+		try {
+			const url = this.configService.get<string>(envKeys.AI.GEMINI.URL);
+			const key = this.configService.get<string>(envKeys.AI.GEMINI.KEY);
+
+			const res = await axios.post<GeminiResponse>(`${url}?key=${key}`, {
+				contents: [{ parts: [{ text: prompt }] }],
+			});
+
+			return res.data;
+		} catch (e) {
+			throw new InternalServerErrorException(
+				'AI 요청 중 오류가 발생했습니다.',
+			);
+		}
+	}
+}

--- a/src/modules/ai/prompt/longAnswer.prompt.ts
+++ b/src/modules/ai/prompt/longAnswer.prompt.ts
@@ -1,0 +1,27 @@
+export const generateLongAnswerPrompt = (
+	category: string,
+	question: string,
+	model: string,
+	answer: string,
+): string => `
+You are an instructor in the field of "${category}".
+
+Evaluate the student's answer based on how well it captures the core meaning and intent of the model answer, and whether it sufficiently responds to the question.
+
+Ignore style, tone, grammar, and phrasing. Focus only on conceptual correctness.
+
+Return only a number score from 0 to 20.
+Do NOT include any explanation, label, or text before or after the score.
+
+[Question]
+${question}
+
+[Model Answer]
+${model}
+
+[Student Answer]
+${answer}
+
+[Response Format]
+<number only, from 0 to 20>
+`;

--- a/src/modules/ai/prompt/modelAnswer.prompt.ts
+++ b/src/modules/ai/prompt/modelAnswer.prompt.ts
@@ -1,0 +1,25 @@
+export const generateModelAnswerPrompt = (
+	category: string,
+	question: string,
+	origin: string,
+) => `
+You are a technical proofreader specializing in the subject of "${category}".
+
+Below is a question and a model answer written by a user.  
+Your task is to revise the answer to ensure accuracy, clarity, and grammatical correctness — without changing its intended meaning.
+
+The revised answer should be suitable for storing in a database as the official answer to the question.
+
+Return only the final revised answer.  
+Do NOT include any labels, explanations, formatting, or introductory text.  
+Do NOT include "Refined Answer:" or any similar prefix.
+
+[Question]
+${question}
+
+[Original Model Answer]
+${origin}
+
+[Response Format]
+<final answer only, no prefix>
+`;

--- a/src/modules/ai/prompt/shortAnswer.prompt.ts
+++ b/src/modules/ai/prompt/shortAnswer.prompt.ts
@@ -1,0 +1,30 @@
+export const generateShortAnswerPrompt = (
+	category: string,
+	question: string,
+	model: string,
+	answer: string,
+) => `
+You are an expert in the field of "${category}".
+
+Determine whether the student's short answer is semantically equivalent to the model answer.
+
+Accept alternate forms such as abbreviations, full expressions, or technical synonyms.
+
+Return only one number:
+- 15 if the answer is correct
+- 0 if the answer is incorrect
+
+Do NOT include any explanation, label, or formatting. Return only the number.
+
+[Question]
+${question}
+
+[Model Answer]
+${model}
+
+[Student Answer]
+${answer}
+
+[Response Format]
+<number only, either 0 or 15>
+`;

--- a/src/modules/ai/utils/ai.utils.ts
+++ b/src/modules/ai/utils/ai.utils.ts
@@ -1,0 +1,34 @@
+import { CategoryType } from 'src/modules/quizbook/schema/quizbook.schema';
+import { GeminiResponse } from '../ai.types';
+
+export function getEnglishCategory(category: CategoryType) {
+	switch (category) {
+		case CategoryType.DATA_STRUCTURE:
+			return 'Data Structures';
+		case CategoryType.ALGORITHM:
+			return 'Algorithms';
+		case CategoryType.NETWORK:
+			return 'Computer Networks';
+		case CategoryType.DATABASE:
+			return 'Databases';
+		case CategoryType.WEB:
+			return 'Web Development';
+		case CategoryType.ETC:
+		default:
+			return 'General Computer Science';
+	}
+}
+
+export function cleanRefinedAnswer(raw: GeminiResponse) {
+	const rawText = raw.candidates[0].content.parts[0].text ?? '';
+
+	return rawText
+		.trim()
+		.replace(/\n+/g, ' ')
+		.replace(/\s+/g, ' ')
+		.replace(/[*_`~>]/g, '')
+		.replace(/[“”]/g, '"')
+		.replace(/[‘’]/g, "'")
+		.replace(/^\.+|\.+$/g, '')
+		.trim();
+}

--- a/src/modules/quiz/dto/create-quiz.dto.ts
+++ b/src/modules/quiz/dto/create-quiz.dto.ts
@@ -44,5 +44,5 @@ export class CreateQuizDto {
 	@IsArray()
 	@ArrayMaxSize(4)
 	@ArrayMinSize(4)
-	options?: string[];
+	optionList?: string[];
 }

--- a/src/modules/quiz/quiz.repository.ts
+++ b/src/modules/quiz/quiz.repository.ts
@@ -24,4 +24,38 @@ export class QuizRepository {
 	async findById(quizId: string) {
 		return this.quizModel.findById(quizId);
 	}
+
+	/**
+	 * 특정 Quiz의 WrongList 업데이트
+	 */
+	async updateWrongList(
+		quizId: string,
+		answer: string,
+		session?: ClientSession,
+	) {
+		return this.quizModel.findByIdAndUpdate(
+			quizId,
+			{
+				$addToSet: { wrongList: answer },
+			},
+			{ new: true, session },
+		);
+	}
+
+	/**
+	 * 특정 Quiz의 SimilarList 업데이트
+	 */
+	async updateSimilarList(
+		quizId: string,
+		answer: string,
+		session?: ClientSession,
+	) {
+		return this.quizModel.findByIdAndUpdate(
+			quizId,
+			{
+				$addToSet: { similarList: answer },
+			},
+			{ new: true, session },
+		);
+	}
 }

--- a/src/modules/quiz/schema/quiz.schema.ts
+++ b/src/modules/quiz/schema/quiz.schema.ts
@@ -23,6 +23,18 @@ export class Quiz extends Document {
 		type: [String],
 	})
 	optionList?: string[];
+
+	@Prop({
+		type: [String],
+		default: [],
+	})
+	similarList: string[];
+
+	@Prop({
+		type: [String],
+		default: [],
+	})
+	wrongList: string[];
 }
 
 export const QuizSchema = SchemaFactory.createForClass(Quiz);

--- a/src/modules/quizbook/quizbook.module.ts
+++ b/src/modules/quizbook/quizbook.module.ts
@@ -9,6 +9,7 @@ import { QuizModule } from '../quiz/quiz.module';
 import { DatabaseModule } from 'src/database/database.module';
 import { LikeModule } from '../like/like.module';
 import { StudyModule } from '../study/study.module';
+import { AIModule } from '../ai/ai.module';
 
 @Module({
 	imports: [
@@ -19,6 +20,7 @@ import { StudyModule } from '../study/study.module';
 		forwardRef(() => QuizModule),
 		forwardRef(() => LikeModule),
 		forwardRef(() => StudyModule),
+		forwardRef(() => AIModule),
 		DatabaseModule,
 	],
 	controllers: [QuizbookController],

--- a/src/modules/quizbook/quizbook.service.ts
+++ b/src/modules/quizbook/quizbook.service.ts
@@ -10,6 +10,9 @@ import { toObjectId } from 'src/common/utils/database.util';
 import { LikeRepository } from '../like/like.repository';
 import { StudyRepository } from '../study/study.repository';
 import { PaginationRequestDto } from 'src/common/dto/pagination.dto';
+import { QuizType } from '../quiz/schema/quiz.schema';
+import { AIService } from '../ai/ai.service';
+import { getXpByType } from '../study/utils/study.utils';
 
 @Injectable()
 export class QuizbookService {
@@ -18,6 +21,7 @@ export class QuizbookService {
 		private readonly quizbookRepo: QuizbookRepository,
 		private readonly likeRepo: LikeRepository,
 		private readonly studyRepo: StudyRepository,
+		private readonly aiService: AIService,
 		private readonly databaseService: DatabaseService,
 	) {}
 	// Quizbook 생성
@@ -26,7 +30,26 @@ export class QuizbookService {
 		return this.databaseService.runInDefaultTransaction(async (session) => {
 			// 1. Quiz 생성
 			const quizList = await Promise.all(
-				dto.quizList.map((data) => this.quizRepo.create(data, session)),
+				dto.quizList.map(async (data) => {
+					if (data.type === QuizType.LONG_ANSWER) {
+						data.answer =
+							await this.aiService.checkModelAnswerWithAI(
+								dto.category,
+								data.question,
+								data.answer,
+							);
+
+						console.log(data.answer);
+					}
+					const quiz = await this.quizRepo.create(data, session);
+
+					return quiz;
+				}),
+			);
+
+			const totalScore = quizList.reduce(
+				(acc, val) => acc + getXpByType(val.type),
+				0,
 			);
 
 			// 2. Quizbook 생성
@@ -34,6 +57,7 @@ export class QuizbookService {
 				{
 					...dto,
 					quizList: quizList.map((q) => toObjectId(q._id as string)),
+					totalScore,
 					author: toObjectId(userId),
 				},
 				session,

--- a/src/modules/quizbook/schema/quizbook.schema.ts
+++ b/src/modules/quizbook/schema/quizbook.schema.ts
@@ -35,6 +35,9 @@ export class Quizbook extends Document {
 	@Prop({ default: 0 })
 	solvedScore: number;
 
+	@Prop({ required: true })
+	totalScore: number;
+
 	@Prop({ default: 0 })
 	reviewCount: number;
 

--- a/src/modules/study/schema/quiz-record.schema.ts
+++ b/src/modules/study/schema/quiz-record.schema.ts
@@ -12,12 +12,6 @@ export enum RoleType {
 export class QuizRecord extends Document {
 	@Prop({
 		required: true,
-		enum: RoleType,
-	})
-	role: RoleType;
-
-	@Prop({
-		required: true,
 		enum: QuizType,
 	})
 	type: QuizType;

--- a/src/modules/study/study.module.ts
+++ b/src/modules/study/study.module.ts
@@ -14,6 +14,8 @@ import { DatabaseModule } from 'src/database/database.module';
 import { LikeModule } from '../like/like.module';
 import { StudyLogModule } from '../study-log/study-log.module';
 import { GroupModule } from '../group/group.module';
+import { AIModule } from '../ai/ai.module';
+import { QuizModule } from '../quiz/quiz.module';
 
 @Module({
 	imports: [
@@ -24,10 +26,12 @@ import { GroupModule } from '../group/group.module';
 			],
 			DB_TYPE.DEFAULT,
 		),
+		forwardRef(() => QuizModule),
 		forwardRef(() => QuizbookModule),
 		forwardRef(() => LikeModule),
 		forwardRef(() => StudyLogModule),
 		forwardRef(() => GroupModule),
+		forwardRef(() => AIModule),
 		DatabaseModule,
 	],
 	controllers: [StudyController],

--- a/src/modules/study/study.service.ts
+++ b/src/modules/study/study.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { StudyRepository } from './study.repository';
 import { SubmitStudyDto } from './dto/submit-study.dto';
-import { Types } from 'mongoose';
+import { ClientSession, Types } from 'mongoose';
 import { Quiz, QuizType } from '../quiz/schema/quiz.schema';
 import { DatabaseService } from 'src/database/database.service';
 import { QuizRecord, RoleType } from './schema/quiz-record.schema';
@@ -11,15 +11,21 @@ import { LikeRepository } from '../like/like.repository';
 import { StudyLogRepository } from '../study-log/study-log.repository';
 import { PaginationRequestDto } from 'src/common/dto/pagination.dto';
 import { GroupRepository } from '../group/group.repository';
+import { getXpByType, isCorrect, isWrong } from './utils/study.utils';
+import { AIService } from '../ai/ai.service';
+import { QuizRepository } from '../quiz/quiz.repository';
+import { CategoryType } from '../quizbook/schema/quizbook.schema';
 
 @Injectable()
 export class StudyService {
 	constructor(
 		private readonly studyRepo: StudyRepository,
+		private readonly quizRepo: QuizRepository,
 		private readonly quizbookRepo: QuizbookRepository,
 		private readonly likeRepo: LikeRepository,
 		private readonly studyLogRepo: StudyLogRepository,
 		private readonly groupRepo: GroupRepository,
+		private readonly aiService: AIService,
 		private readonly databaseService: DatabaseService,
 	) {}
 
@@ -55,38 +61,24 @@ export class StudyService {
 			for (const quiz of quizbook.quizList as Quiz[]) {
 				const quizId = (quiz._id as Types.ObjectId).toString();
 
-				const userAnswer = answerList.find(
+				const answer = answerList.find(
 					(a) => a.quizId === quizId,
 				)?.answer;
 
-				let score = 0;
-
-				if (userAnswer !== undefined) {
-					// OX, 객관식
-					if (
-						[QuizType.OX, QuizType.MULTIPLE_CHOICE].includes(
-							quiz.type,
+				const score = answer
+					? await this.calculateScore(
+							quiz,
+							quizbook.category,
+							answer,
+							session,
 						)
-					) {
-						score =
-							quiz.answer === userAnswer
-								? this.getXpByType(quiz.type)
-								: 0;
-					} else {
-						// 주관식, 서술형
-						score = await this.gradeWithAI(quiz, userAnswer);
-					}
-				} else {
-					// 제출 X
-					score = 0;
-				}
+					: 0;
 
 				totalScore += score;
 
 				const quizRecord = await this.studyRepo.createQuizRecord(
 					{
-						role: RoleType.USER,
-						answer: userAnswer ? userAnswer : ' ',
+						answer: answer ?? ' ',
 						score,
 						quiz: quiz._id as Types.ObjectId,
 						owner: toObjectId(userId),
@@ -285,28 +277,59 @@ export class StudyService {
 	}
 
 	/**
-	 * Quiz 타입별 xp 변환 메서드
+	 * 답안 채점 메서드
+	 * @param quiz Quiz 모델
+	 * @param category Quizbook 카테고리
+	 * @param answer 사용자 답안
+	 * @param session DB 세션
+	 * @returns number 점수
 	 */
-	private getXpByType(type: QuizType): number {
-		switch (type) {
-			case QuizType.OX:
-				return 5;
-			case QuizType.MULTIPLE_CHOICE:
-				return 10;
-			case QuizType.SHORT_ANSWER:
-				return 15;
-			case QuizType.LONG_ANSWER:
-				return 20;
-			default:
-				return 0;
+	private async calculateScore(
+		quiz: Quiz,
+		category: CategoryType,
+		answer: string,
+		session: ClientSession,
+	) {
+		// OX && 객관식
+		if ([QuizType.OX, QuizType.MULTIPLE_CHOICE].includes(quiz.type)) {
+			return quiz.answer === answer ? getXpByType(quiz.type) : 0;
 		}
-	}
 
-	/**
-	 * AI 채점 메서드
-	 */
-	private async gradeWithAI(quiz: Quiz, answer: string): Promise<number> {
-		// 추후 AI 채점 로직으로 대체
-		return quiz.answer === answer ? 10 : 0;
+		// 주관식
+		if (QuizType.SHORT_ANSWER === quiz.type) {
+			// 1. 모범답안 및 유사답안 확인
+			if (isCorrect(quiz, answer)) return getXpByType(quiz.type);
+
+			// 2. 오답안 확인
+			if (isWrong(quiz, answer)) return 0;
+
+			// 3. AI 채점
+			const score = await this.aiService.gradeWithAI(
+				quiz,
+				category,
+				answer,
+			);
+
+			// 4. 정답 여부 확인
+			const xp = getXpByType(quiz.type);
+
+			if (score === xp)
+				await this.quizRepo.updateSimilarList(
+					(quiz._id as Types.ObjectId).toString(),
+					answer,
+					session,
+				);
+			else
+				await this.quizRepo.updateWrongList(
+					(quiz._id as Types.ObjectId).toString(),
+					answer,
+					session,
+				);
+
+			return score;
+		}
+
+		// 서술형
+		return this.aiService.gradeWithAI(quiz, category, answer);
 	}
 }

--- a/src/modules/study/study.service.ts
+++ b/src/modules/study/study.service.ts
@@ -4,7 +4,7 @@ import { SubmitStudyDto } from './dto/submit-study.dto';
 import { ClientSession, Types } from 'mongoose';
 import { Quiz, QuizType } from '../quiz/schema/quiz.schema';
 import { DatabaseService } from 'src/database/database.service';
-import { QuizRecord, RoleType } from './schema/quiz-record.schema';
+import { QuizRecord } from './schema/quiz-record.schema';
 import { toObjectId } from 'src/common/utils/database.util';
 import { QuizbookRepository } from '../quizbook/quizbook.repository';
 import { LikeRepository } from '../like/like.repository';

--- a/src/modules/study/utils/study.utils.ts
+++ b/src/modules/study/utils/study.utils.ts
@@ -1,0 +1,45 @@
+import { Quiz, QuizType } from 'src/modules/quiz/schema/quiz.schema';
+
+export function getXpByType(type: QuizType): number {
+	switch (type) {
+		case QuizType.OX:
+			return 5;
+		case QuizType.MULTIPLE_CHOICE:
+			return 10;
+		case QuizType.SHORT_ANSWER:
+			return 15;
+		case QuizType.LONG_ANSWER:
+			return 20;
+		default:
+			return 0;
+	}
+}
+
+export function normalizeText(input: string) {
+	return input
+		.trim()
+		.toLocaleLowerCase()
+		.replace(/\s+/g, '')
+		.replace(/[^\w가-힣]/g, '');
+}
+
+/**
+ * 채점 유틸 함수
+ * @param quiz Quiz모델
+ * @param answer 사용자 답안
+ * @returns Boolean
+ */
+export function isCorrect(quiz: Quiz, answer: string) {
+	answer = normalizeText(answer);
+	const model = normalizeText(quiz.answer);
+	const similarList = quiz.similarList.map(normalizeText);
+
+	return answer === model || similarList.includes(answer);
+}
+
+export function isWrong(quiz: Quiz, answer: string) {
+	answer = normalizeText(answer);
+	const wrongList = quiz.wrongList.map(normalizeText);
+
+	return wrongList.includes(answer);
+}


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
- 문제집 등록 시 AI를 통한 서술형 정답 검증 로직 구현
- 학습 제출 시 AI 채점 로직 구현 (주관식/서술형 대응)

## 📌 이슈 넘버
> #45 

## 📝 작업 내용
### ✅ 문제집 등록 시
- 서술형 퀴즈의 모범답안을 AI를 통해 자동 정제 및 검수
- Gemini API를 활용하여 정확성, 명확성, 문법적 오류 등을 AI가 판단

### ✅ 학습 제출 시
- 서술형: 매 학습 제출 시 AI를 통한 실시간 채점
- 주관식: AI 요청 최소화를 위한 최적화 로직 설계 및 적용
  - `Quiz` 스키마에 `similarList`, `wrongList` 필드 추가
  - 사용자의 답안이 해당 리스트에 포함되어 있는지 선검사
  - 포함되지 않은 경우에만 AI 채점 요청
  - 응답 결과에 따라 리스트 업데이트 (정답은 `similarList`, 오답은 `wrongList`에 저장)
  - 장기적으로 AI 호출 비용과 횟수 절감을 기대 😍

## 💬리뷰 요구사항
- Gemini를 택한 이유
  - ✅ 분당 15회 요청 가능
  - ✅ 일일 1,500회 요청 가능
  - ✅ 분당 100만 토큰 처리 가능
  - ✅ 입력/출력 모두 무료
  - ✅ 학습 채점 및 답안 정제에 적합한 비용 구조

Closes #45 