### PR TITLE
[Feat] User/Auth 관련 로직 수정

### DIFF
--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -6,9 +6,19 @@ import { AuthService } from './auth.service';
 import { AuthTokenModule } from './auth-token/auth-token.module';
 import { LocalStrategy } from './strategy/local.strategy';
 import { GitHubStrategy } from './strategy/github.strategy';
+import { FollowModule } from '../follow/follow.module';
+import { GroupModule } from '../group/group.module';
+import { StudyLogModule } from '../study-log/study-log.module';
 
 @Module({
-	imports: [UserModule, EmailCodeModule, AuthTokenModule],
+	imports: [
+		UserModule,
+		EmailCodeModule,
+		AuthTokenModule,
+		FollowModule,
+		GroupModule,
+		StudyLogModule,
+	],
 	controllers: [AuthController],
 	providers: [AuthService, LocalStrategy, GitHubStrategy],
 })

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -11,6 +11,12 @@ import { AuthToken } from './auth.types';
 import { ConfigService } from '@nestjs/config';
 import { envKeys } from '../../config/env.const';
 import { OAuthLoginDto } from '../user/dto/oauth-login.dto';
+import { FollowService } from '../follow/follow.service';
+import { GroupService } from '../group/group.service';
+import { UserService } from '../user/user.service';
+import { FollowType } from '../follow/dto/follow-query.dto';
+import { Types } from 'mongoose';
+import { StudyLogRepository } from '../study-log/study-log.repository';
 
 @Injectable()
 export class AuthService {
@@ -18,6 +24,10 @@ export class AuthService {
 		private readonly configService: ConfigService,
 		private readonly authTokenService: AuthTokenService,
 		private readonly userRepository: UserRepository,
+		private readonly studyLogRepository: StudyLogRepository,
+		private readonly userService: UserService,
+		private readonly followService: FollowService,
+		private readonly groupService: GroupService,
 	) {}
 
 	/**
@@ -93,6 +103,51 @@ export class AuthService {
 	 * @param id 해당 사용자의 아이디
 	 */
 	async withdraw(id: string) {
+		// 1. 팔로워 / 팔로잉 삭제
+		const { follower, following } = await this.followService.getAllFollower(
+			id,
+			FollowType.ALL,
+		);
+		await Promise.all([
+			...follower!.map(async ({ _id }) =>
+				this.followService.removeFollow(
+					id,
+					(_id as Types.ObjectId).toString(),
+					FollowType.FOLLOWER,
+				),
+			),
+			...following!.map(async ({ _id }) =>
+				this.followService.removeFollow(
+					id,
+					(_id as Types.ObjectId).toString(),
+					FollowType.FOLLOWING,
+				),
+			),
+		]);
+
+		// 2. 닉네임, 프로필사진 수정
+		await this.userService.updateProfile(id, {
+			nickname: '탈퇴한사용자',
+		});
+		await this.userService.deleteProfileImg(id);
+
+		// 3. 그룹 탈퇴
+		const groups = (
+			await this.groupService.getGroupList(id, {
+				limit: Number.MAX_VALUE,
+				is_mine: true,
+			})
+		).list;
+		await Promise.all(
+			groups.map(async ({ _id }) =>
+				this.groupService.deleteGroupWithdraw(id, _id as string),
+			),
+		);
+
+		// 4. 학습 기록 제거
+		await this.studyLogRepository.deleteLog(id);
+
+		// 5. 최종적으로 탈퇴 처리
 		await this.userRepository.delete(id);
 	}
 

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -16,7 +16,7 @@ import { GroupService } from '../group/group.service';
 import { UserService } from '../user/user.service';
 import { FollowType } from '../follow/dto/follow-query.dto';
 import { Types } from 'mongoose';
-import { StudyLogRepository } from '../study-log/study-log.repository';
+import { StudyLogService } from '../study-log/study-log.service';
 
 @Injectable()
 export class AuthService {
@@ -24,7 +24,7 @@ export class AuthService {
 		private readonly configService: ConfigService,
 		private readonly authTokenService: AuthTokenService,
 		private readonly userRepository: UserRepository,
-		private readonly studyLogRepository: StudyLogRepository,
+		private readonly studyLogService: StudyLogService,
 		private readonly userService: UserService,
 		private readonly followService: FollowService,
 		private readonly groupService: GroupService,
@@ -145,7 +145,7 @@ export class AuthService {
 		);
 
 		// 4. 학습 기록 제거
-		await this.studyLogRepository.deleteLog(id);
+		await this.studyLogService.deleteStudyLog(id);
 
 		// 5. 최종적으로 탈퇴 처리
 		await this.userRepository.delete(id);

--- a/src/modules/follow/follow.controller.ts
+++ b/src/modules/follow/follow.controller.ts
@@ -51,12 +51,12 @@ export class FollowController {
 		description: '타겟 사용자를 팔로우 취소합니다.',
 	})
 	@ApiBaseResponse(200, '취소 성공')
-	removeFollow(
+	async removeFollow(
 		@UserId() userId: string,
 		@Param('targetId', IsObjectIdPipe) targetId: string,
 		@Query() { type }: RemoveFollowQueryDto,
 	) {
-		return this.followService.removeFollow(
+		await this.followService.removeFollow(
 			userId,
 			targetId,
 			type || FollowType.FOLLOWER,

--- a/src/modules/follow/follow.module.ts
+++ b/src/modules/follow/follow.module.ts
@@ -7,5 +7,6 @@ import { UserModule } from '../user/user.module';
 	imports: [UserModule],
 	controllers: [FollowController],
 	providers: [FollowService],
+	exports: [FollowService],
 })
 export class FollowModule {}

--- a/src/modules/follow/follow.service.ts
+++ b/src/modules/follow/follow.service.ts
@@ -93,7 +93,7 @@ export class FollowService {
 		}
 
 		// 구독 취소 처리
-		await Promise.all([
+		return await Promise.all([
 			this.userRepository.update(userId, {
 				$pull: {
 					[type]: targetId,

--- a/src/modules/study-log/study-log.repository.ts
+++ b/src/modules/study-log/study-log.repository.ts
@@ -77,4 +77,12 @@ export class StudyLogRepository {
 			.sort({ date: 1 })
 			.lean();
 	}
+
+	/**
+	 * 특정 user의 study log 제거
+	 * @param userId
+	 */
+	async deleteLog(userId: string) {
+		await this.studyLogModel.deleteMany({ owner: toObjectId(userId) });
+	}
 }

--- a/src/modules/study-log/study-log.service.ts
+++ b/src/modules/study-log/study-log.service.ts
@@ -14,4 +14,9 @@ export class StudyLogService {
 	async findYearlyStuyLogByUser(userId: string, offset: number = 0) {
 		return this.studyLogRepo.findYearly(userId, offset);
 	}
+
+	// 사용자의 StudyLog 제거
+	async deleteStudyLog(userId: string) {
+		return this.studyLogRepo.deleteLog(userId);
+	}
 }

--- a/src/modules/user/schema/user.schema.ts
+++ b/src/modules/user/schema/user.schema.ts
@@ -83,8 +83,8 @@ UserSchema.index({ email: 1, deletedAt: 1 }, { unique: true });
  * User 조회 시 삭제된 유저를 제외하고 조회하기 위한 미들웨어
  */
 UserSchema.pre(/^find/, function (this: Query<any, any>, next) {
-	// populate를 사용해 조회하는 경우 제외
-	if (this.getOptions().populate) {
+	// 직접적으로 조회하지 않는 경우 삭제된 사용자 포함
+	if (this.selected()) {
 		return next();
 	}
 

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -35,12 +35,11 @@ export class UserController {
 	@Get(':id')
 	@ApiOperation({
 		summary: '다른 사용자 정보',
-		description:
-			'다른 사용자의 정보, 학습현황, 문제집리스트(일부)를 가져옵니다.',
+		description: '다른 사용자의 정보를 가져옵니다.',
 	})
 	@ApiBaseResponse(200, '조회 성공', otherExample)
 	async other(@Param('id') id: string) {
-		return await this.userService.getUserAndStudy(id);
+		return await this.userService.getOtherUser(id);
 	}
 
 	@Patch('me')

--- a/src/modules/user/user.example.ts
+++ b/src/modules/user/user.example.ts
@@ -1,5 +1,3 @@
-// import { getQuizbookListEx } from '../quizbook/quizbook.example';
-
 export const meExample = {
 	_id: '65e8a5d6fc13ae5e7f000001',
 	nickname: 'example1',
@@ -17,9 +15,4 @@ export const otherExample = {
 	introduce: '',
 	experience: 0,
 	follower: ['65e8a5d6fc13ae5e7f000001'],
-
-	// 엔드포인트가 따로 파진 관계로 주석 처리 했습니다.
-	// TODO Example 수정 필요
-	// quizbook: getQuizbookListEx,
-	// record: [],
 };

--- a/src/modules/user/user.repository.ts
+++ b/src/modules/user/user.repository.ts
@@ -68,7 +68,6 @@ export class UserRepository {
 	 * @param id
 	 */
 	async delete(id: string) {
-		// TODO 삭제로직 수정
 		return this.userModel.findByIdAndUpdate(id, { deletedAt: new Date() });
 	}
 }

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -33,22 +33,15 @@ export class UserService {
 	}
 
 	/**
-	 * 유저의 정보, 학습 현황, 해당 유저가 만든 문제집 목록 조회
+	 * 다른 유저의 정보 조회
 	 * @param userId
 	 */
-	async getUserAndStudy(userId: string) {
+	async getOtherUser(userId: string) {
 		const user = await this.userRepository.findById(userId);
 
 		if (!user) {
 			throw new NotFoundException('해당 유저를 찾을 수 없습니다.');
 		}
-
-		// 엔드포인트가 따로 파진 관계로 주석 처리 했습니다.
-		// TODO userId로 해당 유저의 quizbook, record 가져오는 서비스
-		// const [quizbook, record] = await Promise.all([
-		// 	new Promise<string[]>((resolve) => resolve([])),
-		// 	new Promise<string[]>((resolve) => resolve([])),
-		// ]);
 
 		return {
 			_id: user._id,
@@ -57,9 +50,6 @@ export class UserService {
 			introduce: user.introduce,
 			experience: user.experience,
 			follower: user.follower,
-			// 엔드포인트가 따로 파진 관계로 주석 처리 했습니다.
-			// quizbook,
-			// record,
 		};
 	}
 


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

User/Auth 관련 로직을 수정했습니다.

## 📌 이슈 넘버

- #38

## 📝 작업 내용

### 다른 사용자 정보 조회 응답 수정

다른 사용자 정보 조회 시 학습 기록 및 문제집 목록을 함께 응답하도록 만들었지만, 학습 기록, 문제집 목록에는 다른 API를 호출하도록 수정했습니다.

### 회원 탈퇴 로직 수정

회원 탈퇴 시 기존에 회원 정보에 deletedAt만 넣도록 만들었지만, 회원이 삭제되면서 함께 삭제되어야하는 데이터는 그대로 남아있었습니다.

그래서 회원 탈퇴 시 구독자, 그룹, 학습 기록을 삭제하고 해당 유저의 프로필사진과 닉네임이 변경되도록 수정했습니다.

최종적으로 사용자 정보 조회 시 직접 조회(사용자 정보 조회, 사용자 팔로우 등)하는 경우에는 탈퇴한 사용자가 나오지 않고, 간접적으로 조회하는 경우에는 "탈퇴한사용자"라고 표시되도록 구현했습니다.

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
