### PR TITLE
[Feat] 모든 그룹 목록 조회 API 추가

### DIFF
--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -133,9 +133,8 @@ export class AuthService {
 
 		// 3. 그룹 탈퇴
 		const groups = (
-			await this.groupService.getGroupList(id, {
+			await this.groupService.getMyGroupList(id, {
 				limit: Number.MAX_VALUE,
-				is_mine: true,
 			})
 		).list;
 		await Promise.all(

--- a/src/modules/group/dto/group-query.dto.ts
+++ b/src/modules/group/dto/group-query.dto.ts
@@ -27,15 +27,6 @@ export class GroupQueryDto {
 	limit: number;
 
 	@ApiProperty({
-		description: '그룹 소속 여부',
-		example: true,
-	})
-	@IsNotEmpty()
-	@IsBoolean()
-	@Transform(({ value }) => Boolean(value))
-	is_mine: boolean;
-
-	@ApiProperty({
 		description: 'Group 제목 검색',
 		example: '서울',
 	})

--- a/src/modules/group/group.controller.ts
+++ b/src/modules/group/group.controller.ts
@@ -17,6 +17,7 @@ import {
 	GroupInfoExample,
 	GroupInviteUrlExample,
 	GroupListExample,
+	MyGroupListExample,
 } from './group.example';
 import { UserId } from 'src/common/decorators/user-id.decorator';
 import { CreateGroupDto } from './dto/create-group.dto';
@@ -24,18 +25,30 @@ import { UpdateOwnerDto } from './dto/update-owner.dto';
 import { CreateGroupMemberDto } from './dto/create-group-member.dto';
 import { RespondApplicationDto } from './dto/patch-respond-application.dto';
 import { GroupQueryDto } from './dto/group-query.dto';
+import { Public } from '../auth/decorator/public.decorator';
 
 @Controller({ path: 'group', version: '1' })
 @ApiTags('Group')
 export class GroupController {
 	constructor(private readonly groupService: GroupService) {}
 
+	@Public()
+	@Get()
+	@ApiOperation({
+		summary: '모든 Group 목록 조회',
+		description: '모든 Group 목록을 조회합니다.',
+	})
+	@ApiBaseResponse(HttpStatus.OK, '조회 성공', GroupListExample)
+	getGroupList(@Query() query: GroupQueryDto) {
+		return this.groupService.getGroupList(query);
+	}
+
 	@Get('my')
 	@ApiOperation({
 		summary: '나의 Group 목록 조회',
 		description: '나의 Group 목록을 조회합니다.',
 	})
-	@ApiBaseResponse(HttpStatus.OK, '조회 성공', GroupListExample)
+	@ApiBaseResponse(HttpStatus.OK, '조회 성공', MyGroupListExample)
 	getMyGroupList(@UserId() userId: string, @Query() query: GroupQueryDto) {
 		return this.groupService.getMyGroupList(userId, query);
 	}

--- a/src/modules/group/group.controller.ts
+++ b/src/modules/group/group.controller.ts
@@ -30,14 +30,14 @@ import { GroupQueryDto } from './dto/group-query.dto';
 export class GroupController {
 	constructor(private readonly groupService: GroupService) {}
 
-	@Get()
+	@Get('my')
 	@ApiOperation({
-		summary: 'Group 목록 조회',
-		description: 'Group 목록을 조회합니다.',
+		summary: '나의 Group 목록 조회',
+		description: '나의 Group 목록을 조회합니다.',
 	})
 	@ApiBaseResponse(HttpStatus.OK, '조회 성공', GroupListExample)
-	getGroupList(@UserId() userId: string, @Query() query: GroupQueryDto) {
-		return this.groupService.getGroupList(userId, query);
+	getMyGroupList(@UserId() userId: string, @Query() query: GroupQueryDto) {
+		return this.groupService.getMyGroupList(userId, query);
 	}
 
 	@Get(':groupId')

--- a/src/modules/group/group.example.ts
+++ b/src/modules/group/group.example.ts
@@ -6,9 +6,23 @@ export const GroupListExample = {
 			description:
 				'서울에 사는 컴공 취준생들의 cs 공부 스터디 그룹입니다.',
 			admin: {},
+			memberCount: '7',
+		},
+	],
+	nextCursor: '65e8a5d6fc13ae5e7f000002',
+	leftCount: 24,
+};
+
+export const MyGroupListExample = {
+	list: [
+		{
+			_id: '65e8a5d6fc13ae5e7f000002',
+			name: '서울 강남 cs 공부 스터디',
+			description:
+				'서울에 사는 컴공 취준생들의 cs 공부 스터디 그룹입니다.',
+			admin: {},
 			chatRoom: '65e8a5d6fc13ae5e7f000002',
 			memberCount: '7',
-			is_mine: true,
 		},
 	],
 	nextCursor: '65e8a5d6fc13ae5e7f000002',

--- a/src/modules/group/group.repository.ts
+++ b/src/modules/group/group.repository.ts
@@ -22,13 +22,13 @@ export class GroupRepository {
 	/**
 	 * Group 목록 조회
 	 */
-	async findGroupList(memberId: Types.ObjectId, query: GroupQueryDto) {
-		const { cursor, limit, is_mine, name } = query;
+	async findGroupList(query: GroupQueryDto, memberId?: Types.ObjectId) {
+		const { cursor, limit, name } = query;
 
 		const filter: GroupQuery = {};
 
 		if (cursor) filter.cursor = { $lt: toObjectId(cursor) };
-		if (is_mine) filter.memberList = { $in: [memberId] };
+		if (memberId) filter.memberList = { $in: [memberId] };
 		if (name) filter.name = { $regex: name, $options: 'i' };
 
 		return this.groupModel
@@ -47,13 +47,13 @@ export class GroupRepository {
 	/**
 	 * Group 전체 개수 동기화를 위한 남은 개수 조회
 	 */
-	async findLeftCount(memberId: Types.ObjectId, query: GroupQueryDto) {
-		const { cursor, is_mine, name } = query;
+	async findLeftCount(query: GroupQueryDto, memberId?: Types.ObjectId) {
+		const { cursor, name } = query;
 
 		const filter: GroupQuery = {};
 
 		if (cursor) filter.cursor = { $lt: toObjectId(cursor) };
-		if (is_mine) filter.memberList = { $in: [memberId] };
+		if (memberId) filter.memberList = { $in: [memberId] };
 		if (name) filter.name = { $regex: name, $options: 'i' };
 
 		return this.groupModel.countDocuments(filter);

--- a/src/modules/group/group.service.ts
+++ b/src/modules/group/group.service.ts
@@ -29,15 +29,15 @@ export class GroupService {
 		private readonly readStatusRepository: ReadStatusRepository,
 	) {}
 
-	async getGroupList(userId: string, query: GroupQueryDto) {
+	async getMyGroupList(userId: string, query: GroupQueryDto) {
 		const groupList = await this.groupRepository.findGroupList(
-			toObjectId(userId),
 			query,
+			toObjectId(userId),
 		);
 
 		const leftCount = await this.groupRepository.findLeftCount(
-			toObjectId(userId),
 			query,
+			toObjectId(userId),
 		);
 
 		// 그룹 정보를 변환

--- a/src/modules/group/group.service.ts
+++ b/src/modules/group/group.service.ts
@@ -29,6 +29,49 @@ export class GroupService {
 		private readonly readStatusRepository: ReadStatusRepository,
 	) {}
 
+	async getGroupList(query: GroupQueryDto) {
+		const groupList = await this.groupRepository.findGroupList(query);
+
+		const leftCount = await this.groupRepository.findLeftCount(query);
+
+		// 그룹 정보를 변환
+		const transformedGroups = groupList.map((group) => {
+			const {
+				memberList,
+				applyingUserList,
+				groupQuizbookList,
+				createdAt,
+				updatedAt,
+				chatRoom,
+				...filteredFields
+			} = group.toObject();
+
+			// 간단히 변수 사용 처리
+			void applyingUserList;
+			void groupQuizbookList;
+			void createdAt;
+			void updatedAt;
+			void chatRoom;
+
+			// memberCount 계산
+			const memberCount = memberList.length;
+
+			return {
+				...filteredFields,
+				memberCount,
+			};
+		});
+
+		return {
+			list: transformedGroups,
+			nextCursor:
+				transformedGroups.length > 0
+					? transformedGroups[transformedGroups.length - 1]._id
+					: null,
+			leftCount: leftCount - transformedGroups.length,
+		};
+	}
+
 	async getMyGroupList(userId: string, query: GroupQueryDto) {
 		const groupList = await this.groupRepository.findGroupList(
 			query,
@@ -60,14 +103,9 @@ export class GroupService {
 			// memberCount 계산
 			const memberCount = memberList.length;
 
-			// 소속 여부
-			const targetMemberList = memberList.map((user) => user.toString());
-			const indexOfUser = targetMemberList.indexOf(userId);
-
 			return {
 				...filteredFields,
 				memberCount,
-				is_mine: indexOfUser !== -1,
 			};
 		});
 


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

- 하나의 api로 모든 그룹 조회 및 나의 그룹 조회를 쿼리에 따라 처리하려고 했었지만, 인증 여부를 기준으로 api를 분리하기 위해 나의 그룹 목록 조회와 모든 그룹 목록 조회로 api를 분리하였습니다.

## 📌 이슈 넘버

- #39 

## 📝 작업 내용

- 모든 그룹 목록 조회 api 추가
- 나의 그룹 목록 조회 api 필터 조건 제거
- 관련 메소드 사용 코드 수정
- Swagger api 문서화 작업 ([API 명세](https://api.quizbank.store/))

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

close #39 