### PR TITLE
[Feat] 그룹 문제집 선정 API 수정

### DIFF
--- a/src/modules/group/group-quizbook/group-quizbook.service.ts
+++ b/src/modules/group/group-quizbook/group-quizbook.service.ts
@@ -1,4 +1,5 @@
 import {
+	ConflictException,
 	Injectable,
 	NotFoundException,
 	UnauthorizedException,
@@ -8,6 +9,7 @@ import { DatabaseService } from 'src/database/database.service';
 import { GroupRepository } from '../group.repository';
 import { toObjectId } from 'src/common/utils/database.util';
 import { GroupQuizbookQueryDto } from './dto/group-quizbook-query.dto';
+import { GroupQuizbook } from './schema/group-quizbook.schema';
 
 @Injectable()
 export class GroupQuizbookService {
@@ -79,6 +81,13 @@ export class GroupQuizbookService {
 
 			if (group.admin._id.toString() !== userId)
 				throw new UnauthorizedException(`허가되지 않는 접근입니다.`);
+
+			const targetGroupQuizbookList = group.groupQuizbookList.map(
+				(data: GroupQuizbook) => data.quizbook.toString(),
+			);
+			const index = targetGroupQuizbookList.indexOf(quizbookId);
+			if (index !== -1)
+				throw new ConflictException(`이미 선정된 문제집입니다.`);
 
 			// endDate의 시간 부분을 23:59:59.999로 설정
 			const endedAt = new Date(endDate);

--- a/src/modules/group/group.repository.ts
+++ b/src/modules/group/group.repository.ts
@@ -82,7 +82,6 @@ export class GroupRepository {
 			{
 				path: 'groupQuizbookList',
 				model: 'GroupQuizbook',
-				select: 'quizbook',
 			},
 		]);
 	}

--- a/src/modules/group/group.repository.ts
+++ b/src/modules/group/group.repository.ts
@@ -79,6 +79,11 @@ export class GroupRepository {
 				model: 'User',
 				select: 'nickname profileImg email',
 			},
+			{
+				path: 'groupQuizbookList',
+				model: 'GroupQuizbook',
+				select: 'quizbook',
+			},
 		]);
 	}
 

--- a/src/modules/group/schema/group.schema.ts
+++ b/src/modules/group/schema/group.schema.ts
@@ -1,5 +1,6 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document, Types } from 'mongoose';
+import { GroupQuizbook } from '../group-quizbook/schema/group-quizbook.schema';
 
 @Schema({ timestamps: true })
 export class Group extends Document {
@@ -28,7 +29,7 @@ export class Group extends Document {
 		type: [{ type: Types.ObjectId, ref: 'GroupQuizbook' }],
 		default: [],
 	})
-	groupQuizbookList: Types.ObjectId[];
+	groupQuizbookList: (Types.ObjectId | GroupQuizbook)[];
 
 	@Prop({ type: Types.ObjectId, ref: 'ChatRoom', required: true })
 	chatRoom: Types.ObjectId;


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

- 그룹 문제집 선정 api 요청 시, 이미 등록된 문제집에 대한 예외 처리를 추가했습니다.

## 📌 이슈 넘버

- #53 

## 📝 작업 내용

- Group 스키마 타입 수정
- Group 레포지토리 populate 추가
- GroupQuizbook 서비스의 postCreateGroupQuizbook 메소드에 예외처리 로직 추가

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

close #53 
