### PR TITLE
[Feat] 그룹 관련 API 수정

### DIFF
--- a/src/modules/group/group-quizbook/group-quizbook.service.ts
+++ b/src/modules/group/group-quizbook/group-quizbook.service.ts
@@ -81,13 +81,13 @@ export class GroupQuizbookService {
 		if (group.admin._id.toString() !== userId)
 			throw new UnauthorizedException(`허가되지 않는 접근입니다.`);
 
-    const targetGroupQuizbookList = group.groupQuizbookList.map(
-		  (data: GroupQuizbook) => data.quizbook.toString(),
+		const targetGroupQuizbookList = group.groupQuizbookList.map(
+			(data: GroupQuizbook) => data.quizbook.toString(),
 		);
 		const index = targetGroupQuizbookList.indexOf(quizbookId);
-			if (index !== -1)
-				throw new ConflictException(`이미 선정된 문제집입니다.`);
-      
+		if (index !== -1)
+			throw new ConflictException(`이미 선정된 문제집입니다.`);
+
 		await this.databaseService.runInDefaultTransaction(async (session) => {
 			// endDate의 시간 부분을 23:59:59.999로 설정
 			const endedAt = new Date(endDate);

--- a/src/modules/group/group.controller.ts
+++ b/src/modules/group/group.controller.ts
@@ -113,7 +113,7 @@ export class GroupController {
 		await this.groupService.patchGroupApplying(userId, groupId);
 	}
 
-	@Patch(':groupId/application-response')
+	@Patch(':groupId/application/:memberId/response')
 	@ApiOperation({
 		summary: 'Group 가입 요청 처리(수락 또는 거절)',
 		description: 'Group 가입 요청을 수락 또는 거절 처리합니다.',
@@ -122,11 +122,13 @@ export class GroupController {
 	async patchRespondToApplication(
 		@UserId() userId: string,
 		@Param('groupId') groupId: string,
+		@Param('memberId') memberId: string,
 		@Body() request: RespondApplicationDto,
 	) {
 		await this.groupService.patchRespondToApplication(
 			userId,
 			groupId,
+			memberId,
 			request.accepted,
 		);
 	}

--- a/src/modules/group/group.service.ts
+++ b/src/modules/group/group.service.ts
@@ -18,6 +18,8 @@ import { ReadStatusRepository } from '../chat/repository/read-status.repository'
 import { ChatRoomType } from '../chat/schema/chat-room.schema';
 import { GroupQueryDto } from './dto/group-query.dto';
 import { GroupQuizbook } from './group-quizbook/schema/group-quizbook.schema';
+import { ConfigService } from '@nestjs/config';
+import { envKeys } from 'src/config/env.const';
 
 @Injectable()
 export class GroupService {
@@ -28,6 +30,7 @@ export class GroupService {
 		private readonly groupQuizbookRepository: GroupQuizbookRepository,
 		private readonly chatRoomRepository: ChatRoomRepository,
 		private readonly readStatusRepository: ReadStatusRepository,
+		private readonly configService: ConfigService,
 	) {}
 
 	async getGroupList(query: GroupQueryDto) {
@@ -324,8 +327,14 @@ export class GroupService {
 				{ groupId },
 			);
 
-		// 추후 url 수정 필요.
-		return { url: `http://localhost:3000/auth/login?token=${token}` };
+		const isDev = this.configService.get<string>(envKeys.ENV) === 'dev';
+		const clientUrl = this.configService.get<string>(
+			isDev ? envKeys.CLIENT.LOCAL : envKeys.CLIENT.PROD,
+		);
+
+		return {
+			url: `${clientUrl}/login?token=${token}`,
+		};
 	}
 
 	async postCreateGroupMember(userId: string, token: string) {

--- a/src/modules/group/group.service.ts
+++ b/src/modules/group/group.service.ts
@@ -306,7 +306,31 @@ export class GroupService {
 				$pull: { applyingUserList: toObjectId(memberId) },
 			};
 		}
-		await this.groupRepository.update(filter, groupId);
+
+		await this.databaseService.runInDefaultTransaction(async (session) => {
+			await this.groupRepository.update(filter, groupId, session);
+
+			if (accepted) {
+				// 새 그룹원의 ReadStatus 생성
+				await this.readStatusRepository.create(
+					{
+						chatRoom: group.chatRoom,
+						lastTimestamp: new Date(),
+						member: toObjectId(memberId),
+					},
+					session,
+				);
+
+				// 새 그룹원을 ChatRoom member에 추가
+				await this.chatRoomRepository.update(
+					{
+						$addToSet: { memberList: toObjectId(memberId) },
+					},
+					group.chatRoom,
+					session,
+				);
+			}
+		});
 	}
 
 	async getInviteUrl(userId: string, groupId: string) {
@@ -359,10 +383,19 @@ export class GroupService {
 				`해당 ${groupId} Group을 찾을 수 없습니다.`,
 			);
 
+		// 이미 그룹원인지 확인
+		const targetMemberList = group.memberList.map((user) =>
+			user._id.toString(),
+		);
+		const indexOfNewOwner = targetMemberList.indexOf(userId);
+
+		if (indexOfNewOwner !== -1) return;
+
 		await this.databaseService.runInDefaultTransaction(async (session) => {
 			await this.groupRepository.update(
 				{
 					$addToSet: { memberList: toObjectId(userId) }, // 중복 없이 배열에 userId 추가
+					$pull: { applyingUserList: toObjectId(userId) },
 				},
 				groupId,
 				session,

--- a/src/modules/group/group.service.ts
+++ b/src/modules/group/group.service.ts
@@ -263,7 +263,7 @@ export class GroupService {
 
 		await this.groupRepository.update(
 			{
-				$addToSet: { applyingUserList: userId },
+				$addToSet: { applyingUserList: toObjectId(userId) },
 			},
 			groupId,
 		);
@@ -298,12 +298,12 @@ export class GroupService {
 		let filter: FilterQuery<Group>;
 		if (accepted) {
 			filter = {
-				$pull: { applyingUserList: memberId },
-				$addToSet: { memberList: memberId },
+				$pull: { applyingUserList: toObjectId(memberId) },
+				$addToSet: { memberList: toObjectId(memberId) },
 			};
 		} else {
 			filter = {
-				$pull: { applyingUserList: memberId },
+				$pull: { applyingUserList: toObjectId(memberId) },
 			};
 		}
 		await this.groupRepository.update(filter, groupId);
@@ -362,7 +362,7 @@ export class GroupService {
 		await this.databaseService.runInDefaultTransaction(async (session) => {
 			await this.groupRepository.update(
 				{
-					$addToSet: { memberList: userId }, // 중복 없이 배열에 userId 추가
+					$addToSet: { memberList: toObjectId(userId) }, // 중복 없이 배열에 userId 추가
 				},
 				groupId,
 				session,
@@ -371,7 +371,7 @@ export class GroupService {
 			// 그룹의 ChatRoom에 그룹원 추가
 			await this.chatRoomRepository.update(
 				{
-					$addToSet: { memberList: userId }, // 중복 없이 배열에 userId 추가
+					$addToSet: { memberList: toObjectId(userId) }, // 중복 없이 배열에 userId 추가
 				},
 				group.chatRoom,
 				session,
@@ -419,7 +419,7 @@ export class GroupService {
 		await this.groupRepository.update(
 			{
 				admin: toObjectId(memberId),
-				memberList: targetMemberList,
+				memberList: targetMemberList.map((data) => toObjectId(data)),
 			},
 			groupId,
 		);
@@ -456,10 +456,10 @@ export class GroupService {
 			if (group.admin._id.toString() === userId) {
 				data = {
 					admin: group.memberList[1]._id,
-					$pull: { memberList: userId },
+					$pull: { memberList: toObjectId(userId) },
 				};
 			} else {
-				data = { $pull: { memberList: userId } };
+				data = { $pull: { memberList: toObjectId(userId) } };
 			}
 
 			await this.groupRepository.update(data, groupId, session);
@@ -474,7 +474,7 @@ export class GroupService {
 			// 그룹의 ChatRoom에 그룹원 삭제
 			await this.chatRoomRepository.update(
 				{
-					$pull: { memberList: userId },
+					$pull: { memberList: toObjectId(userId) },
 				},
 				group.chatRoom,
 				session,
@@ -495,7 +495,7 @@ export class GroupService {
 
 		await this.databaseService.runInDefaultTransaction(async (session) => {
 			await this.groupRepository.update(
-				{ $pull: { memberList: memberId } },
+				{ $pull: { memberList: toObjectId(memberId) } },
 				groupId,
 				session,
 			);
@@ -510,7 +510,7 @@ export class GroupService {
 			// 그룹의 ChatRoom에 그룹원 삭제
 			await this.chatRoomRepository.update(
 				{
-					$pull: { memberList: memberId },
+					$pull: { memberList: toObjectId(memberId) },
 				},
 				group.chatRoom,
 				session,

--- a/src/modules/group/group.service.ts
+++ b/src/modules/group/group.service.ts
@@ -272,6 +272,7 @@ export class GroupService {
 	async patchRespondToApplication(
 		userId: string,
 		groupId: string,
+		memberId: string,
 		accepted: boolean,
 	) {
 		const group = await this.groupRepository.findById(groupId);
@@ -281,25 +282,28 @@ export class GroupService {
 				`해당 ${groupId} Group을 찾을 수 없습니다.`,
 			);
 
+		if (group.admin._id.toString() !== userId)
+			throw new UnauthorizedException(`허가되지 않는 접근입니다.`);
+
 		const targetApplyingUserList = group.applyingUserList.map((user) =>
 			user._id.toString(),
 		);
-		const indexOfApplyingUser = targetApplyingUserList.indexOf(userId);
+		const indexOfApplyingUser = targetApplyingUserList.indexOf(memberId);
 
 		if (indexOfApplyingUser === -1)
 			throw new NotFoundException(
-				`해당 ${userId} 사용자는 그룹에 가입 요청을 하지 않았습니다.`,
+				`해당 ${memberId} 사용자는 그룹에 가입 요청을 하지 않았습니다.`,
 			);
 
 		let filter: FilterQuery<Group>;
 		if (accepted) {
 			filter = {
-				$pull: { applyingUserList: userId },
-				$addToSet: { memberList: userId },
+				$pull: { applyingUserList: memberId },
+				$addToSet: { memberList: memberId },
 			};
 		} else {
 			filter = {
-				$pull: { applyingUserList: userId },
+				$pull: { applyingUserList: memberId },
 			};
 		}
 		await this.groupRepository.update(filter, groupId);

--- a/src/modules/group/group.service.ts
+++ b/src/modules/group/group.service.ts
@@ -17,6 +17,7 @@ import { ChatRoomRepository } from '../chat/repository/chat-room.repository';
 import { ReadStatusRepository } from '../chat/repository/read-status.repository';
 import { ChatRoomType } from '../chat/schema/chat-room.schema';
 import { GroupQueryDto } from './dto/group-query.dto';
+import { GroupQuizbook } from './group-quizbook/schema/group-quizbook.schema';
 
 @Injectable()
 export class GroupService {
@@ -219,12 +220,14 @@ export class GroupService {
 
 		await this.databaseService.runInDefaultTransaction(async (session) => {
 			await Promise.all(
-				group.groupQuizbookList.map(async (groupQuizbook) => {
-					await this.groupQuizbookRepository.deleteById(
-						groupQuizbook.toString(),
-						session,
-					);
-				}),
+				(group.groupQuizbookList as GroupQuizbook[]).map(
+					async (groupQuizbook) => {
+						await this.groupQuizbookRepository.deleteById(
+							(groupQuizbook._id as Types.ObjectId).toString(),
+							session,
+						);
+					},
+				),
 			);
 
 			// 그룹원들의 ReadStatus 제거


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

- 이전 Group repository에 populate 추가로 인한 그룹 삭제 api의 객체 필드 참조 수정했습니다.
- 그룹 초대 링크 조회 api의 반환값 수정했습니다.
- 그룹 가입 요청 처리 api의 설계 오류로 가입 요청자가 아닌 그룹장의 ID로 가입 요청 여부를 검사하는 오류 및 새 그룹원의 readStatus생성과 chatRoom 멤버가 수정되지 않아 이를 수정했습니다.
- 초대 링크를 통한 그룹 가입 api에서 이미 그룹원인지 확인하고 applyingUserList 이미 존재한다면 제거하는 로직 추가합니다.

## 📌 이슈 넘버

- #58 

## 📝 작업 내용

- 그룹 삭제 api 객체 필드 참조 수정
- 그룹 초대 링크 조회 api 반환값 수정 (조건부 처리)
- 그룹 가입 요청 처리 api 로직 수정
- 초대 링크를 통한 그룹 가입 api 로직 수정

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

close #58 
