### PR TITLE
[Feat] 소켓 채팅 송수신 로직 및 채팅 내역 조회 API 수정

### DIFF
--- a/src/modules/chat/chat.gateway.ts
+++ b/src/modules/chat/chat.gateway.ts
@@ -20,7 +20,6 @@ import { ChatRepository } from './repository/chat.repository';
 import { toObjectId } from 'src/common/utils/database.util';
 import { ReadStatusRepository } from './repository/read-status.repository';
 import { UserRepository } from '../user/user.repository';
-import { Types } from 'mongoose';
 
 interface AuthenticatedSocket extends Socket {
 	data: {
@@ -115,6 +114,11 @@ export class ChatGateway
 		const { chatRoomId, content } = data;
 		const userId = socket.data.user.userId;
 
+		// 내 정보 조회
+		const myInfo = await this.userRepository.findById(userId);
+		if (!myInfo)
+			throw new WsException(`해당 ${userId} 유저를 찾을 수 없습니다.`);
+
 		// chat 생성 로직
 		const newChat = await this.chatRepository.create({
 			chatRoom: toObjectId(chatRoomId),
@@ -122,18 +126,21 @@ export class ChatGateway
 			content,
 		});
 
-		// 내 정보 조회
-		const myInfo = await this.userRepository.findById(userId);
-		if (!myInfo)
-			throw new WsException(`해당 ${userId} 유저를 찾을 수 없습니다.`);
+		// readStatus 갱신 로직
+		const now = new Date();
+		await this.readStatusRepository.update(
+			{ lastTimestamp: now },
+			toObjectId(userId),
+			toObjectId(chatRoomId),
+		);
 
 		socket.to(chatRoomId).emit('receive_chat', {
-			...newChat,
-			sender: {
-				_id: myInfo._id,
-				nickname: myInfo.nickname,
-				profileImg: myInfo.profileImg,
-			},
+			_id: newChat._id,
+			chatRoom: chatRoomId,
+			sender: myInfo._id,
+			content: content,
+			createdAt: newChat.createdAt,
+			updatedAt: newChat.updatedAt,
 		});
 	}
 }

--- a/src/modules/chat/chat.service.ts
+++ b/src/modules/chat/chat.service.ts
@@ -33,6 +33,7 @@ export class ChatService {
 			throw new UnauthorizedException(`허가되지 않는 접근입니다.`);
 
 		const { cursor, take } = query;
+
 		const chats = await this.chatRepository.findList(
 			toObjectId(chatRoomId),
 			cursor ? new Date(cursor) : new Date(),
@@ -41,8 +42,7 @@ export class ChatService {
 
 		return {
 			chats: chats.reverse(),
-			nextCursor:
-				chats.length > 0 ? chats[chats.length - 1].createdAt : null,
+			nextCursor: chats.length > 0 ? chats[0].createdAt : null,
 		};
 	}
 
@@ -77,8 +77,6 @@ export class ChatService {
 	}
 
 	async patchReadStatus(userId: string, chatRoomId: string) {
-		const now = new Date();
-
 		const chatRoom = await this.chatRoomRepository.findById(chatRoomId);
 
 		if (!chatRoom)
@@ -88,6 +86,8 @@ export class ChatService {
 
 		if (!chatRoom.memberList.map((id) => id.toString()).includes(userId))
 			throw new UnauthorizedException(`허가되지 않는 접근입니다.`);
+
+		const now = new Date();
 
 		// readStatus 갱신 로직
 		await this.readStatusRepository.update(

--- a/src/modules/chat/repository/chat.repository.ts
+++ b/src/modules/chat/repository/chat.repository.ts
@@ -26,21 +26,11 @@ export class ChatRepository {
 			query.createdAt = { $lt: cursor };
 		}
 
-		return this.chatModel
-			.find(query)
-			.sort({ createdAt: -1 })
-			.limit(take)
-			.populate([
-				{
-					path: 'sender',
-					model: 'User',
-					select: 'nickname profileImg',
-				},
-			]);
+		return this.chatModel.find(query).sort({ createdAt: -1 }).limit(take);
 	}
 
 	/**
-	 * 채팅 내역 조회
+	 * 안읽은 채팅 내역 조회
 	 */
 	async findUnreadList(chatRoom: Types.ObjectId, date: Date) {
 		return this.chatModel.find({ chatRoom, createdAt: { $gt: date } });


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

- 소켓 채팅 송수신 로직과 채팅 내역 조회 API를 수정했습니다.

## 📌 이슈 넘버

- #61 

## 📝 작업 내용

### ✅ API 관련

- chat repository 메소드 populate 제거
> [!NOTE]
> mongoDB의 서로 다른 클러스터에 존재하는 모델들은 서로 populate 불가하여 제거했습니다.

- 채팅 내역 조회 API 반환값 수정

### ✅ 소켓 관련

- 채팅 수신 반환값 수정
- 채팅 송신시, 채팅 읽음 처리

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

close #61 
