### PR TITLE
[Feat] 나의 그룹 목록 조회 API 수정 및 소켓 이벤트 핸들러 추가

### DIFF
--- a/src/modules/chat/chat.gateway.ts
+++ b/src/modules/chat/chat.gateway.ts
@@ -105,6 +105,16 @@ export class ChatGateway
 		}
 	}
 
+	@SubscribeMessage('leave_chat')
+	async handleLeaveChat(
+		@ConnectedSocket() socket: AuthenticatedSocket,
+		@MessageBody() chatRoomIds: string[],
+	) {
+		for (const chatRoomId of chatRoomIds) {
+			await socket.leave(chatRoomId);
+		}
+	}
+
 	@SubscribeMessage('send_chat')
 	async handleSendChat(
 		@ConnectedSocket() socket: AuthenticatedSocket,

--- a/src/modules/group/group.example.ts
+++ b/src/modules/group/group.example.ts
@@ -23,6 +23,7 @@ export const MyGroupListExample = {
 			admin: {},
 			chatRoom: '65e8a5d6fc13ae5e7f000002',
 			memberCount: '7',
+			unreadMessageCount: 10,
 		},
 	],
 	nextCursor: '65e8a5d6fc13ae5e7f000002',

--- a/src/modules/group/group.repository.ts
+++ b/src/modules/group/group.repository.ts
@@ -7,7 +7,7 @@ import { GroupQueryDto } from './dto/group-query.dto';
 import { toObjectId } from 'src/common/utils/database.util';
 
 interface GroupQuery {
-	cursor?: { $lt: Types.ObjectId };
+	_id?: { $lt: Types.ObjectId };
 	memberList?: { $in: [Types.ObjectId] };
 	name?: { $regex: string; $options: string };
 }
@@ -27,7 +27,7 @@ export class GroupRepository {
 
 		const filter: GroupQuery = {};
 
-		if (cursor) filter.cursor = { $lt: toObjectId(cursor) };
+		if (cursor) filter._id = { $lt: toObjectId(cursor) };
 		if (memberId) filter.memberList = { $in: [memberId] };
 		if (name) filter.name = { $regex: name, $options: 'i' };
 
@@ -52,7 +52,7 @@ export class GroupRepository {
 
 		const filter: GroupQuery = {};
 
-		if (cursor) filter.cursor = { $lt: toObjectId(cursor) };
+		if (cursor) filter._id = { $lt: toObjectId(cursor) };
 		if (memberId) filter.memberList = { $in: [memberId] };
 		if (name) filter.name = { $regex: name, $options: 'i' };
 

--- a/src/modules/group/group.service.ts
+++ b/src/modules/group/group.service.ts
@@ -20,6 +20,7 @@ import { GroupQueryDto } from './dto/group-query.dto';
 import { GroupQuizbook } from './group-quizbook/schema/group-quizbook.schema';
 import { ConfigService } from '@nestjs/config';
 import { envKeys } from 'src/config/env.const';
+import { ChatService } from '../chat/chat.service';
 
 @Injectable()
 export class GroupService {
@@ -31,6 +32,7 @@ export class GroupService {
 		private readonly chatRoomRepository: ChatRoomRepository,
 		private readonly readStatusRepository: ReadStatusRepository,
 		private readonly configService: ConfigService,
+		private readonly chatService: ChatService,
 	) {}
 
 	async getGroupList(query: GroupQueryDto) {
@@ -88,30 +90,40 @@ export class GroupService {
 		);
 
 		// 그룹 정보를 변환
-		const transformedGroups = groupList.map((group) => {
-			const {
-				memberList,
-				applyingUserList,
-				groupQuizbookList,
-				createdAt,
-				updatedAt,
-				...filteredFields
-			} = group.toObject();
+		const transformedGroups = await Promise.all(
+			groupList.map(async (group) => {
+				const {
+					memberList,
+					applyingUserList,
+					groupQuizbookList,
+					createdAt,
+					updatedAt,
+					...filteredFields
+				} = group.toObject();
 
-			// 간단히 변수 사용 처리
-			void applyingUserList;
-			void groupQuizbookList;
-			void createdAt;
-			void updatedAt;
+				// 간단히 변수 사용 처리
+				void applyingUserList;
+				void groupQuizbookList;
+				void createdAt;
+				void updatedAt;
 
-			// memberCount 계산
-			const memberCount = memberList.length;
+				// memberCount 계산
+				const memberCount = memberList.length;
 
-			return {
-				...filteredFields,
-				memberCount,
-			};
-		});
+				// 안읽은 채팅 메세지 개수 계산
+				const { count: unreadMessageCount } =
+					await this.chatService.getGroupChatUnreadCount(
+						userId,
+						group.chatRoom.toString(),
+					);
+
+				return {
+					...filteredFields,
+					memberCount,
+					unreadMessageCount,
+				};
+			}),
+		);
 
 		return {
 			list: transformedGroups,


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

- 나의 그룹 목록 조회 api를 수정하고 소켓 이벤트 핸들러를 추가했습니다.

## 📌 이슈 넘버

- #64 

## 📝 작업 내용

### ✅ 나의 그룹 목록 조회 api 수정
- 내가 소속된 그룹의 안읽은 채팅 메세지 개수를 반환값으로 추가

### ✅ 소켓 이벤트 핸들러 추가
- 소켓 room 연결 해제를 위한 leave_chat 핸들러 추가

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

close #64 
