### PR TITLE
[Refactor] 생성 관련 API 응답값 result 추가

### DIFF
--- a/src/modules/comment/comment.controller.ts
+++ b/src/modules/comment/comment.controller.ts
@@ -15,6 +15,7 @@ import { UpdateCommentDto } from './dto/update-comment.dto';
 import { ApiOperation } from '@nestjs/swagger';
 import { ApiBaseResponse } from 'src/common/decorators/base-response.decorator';
 import {
+	createCommentEx,
 	getCommentDetailEx,
 	getCommentListEx,
 	getMyCommentEx,
@@ -37,7 +38,7 @@ export class CommentController {
 		description:
 			'특정 Quiz에 대한 Comment를 생성합니다. (commentId 전달시 ReComment로 인식)',
 	})
-	@ApiBaseResponse(201, '생성 성공')
+	@ApiBaseResponse(201, '생성 성공', createCommentEx)
 	createComment(@Body() dto: CreateCommentDto, @UserId() userId: string) {
 		return this.commentService.createComment(dto, userId);
 	}

--- a/src/modules/comment/comment.example.ts
+++ b/src/modules/comment/comment.example.ts
@@ -1,3 +1,13 @@
+export const createCommentEx = {
+	_id: '67fe3f484d188f97d2aec4cf',
+	content: 'Comment 생성 테스트',
+	quiz: '67fdc5ac1e49a2871aeb6651',
+	author: '67fe18f8bb486fc72e9a8004',
+	createdAt: '2025-04-15T11:13:12.456Z',
+	updatedAt: '2025-04-15T11:23:01.730Z',
+	__v: 0,
+};
+
 export const updateCommentEx = {
 	_id: '67fe3f484d188f97d2aec4cf',
 	content: 'Comment 수정 테스트',

--- a/src/modules/comment/comment.example.ts
+++ b/src/modules/comment/comment.example.ts
@@ -55,35 +55,21 @@ export const getMyCommentEx = {
 };
 
 export const getCommentDetailEx = {
-	comment: {
-		_id: '67fdc72a1e49a2871aeb66cd',
-		content: 'Comment 수정 테스트',
-		quiz: '67fdc5ac1e49a2871aeb6651',
-		author: {
-			_id: '67e2e20e5872c849d5dd4b86',
-			nickname: 'test계정',
-		},
-		createdAt: '2025-04-15T02:40:42.805Z',
-		updatedAt: '2025-04-15T02:41:30.812Z',
-		__v: 0,
-	},
-	recomment: {
-		data: [
-			{
-				_id: '67fdc8c61e49a2871aeb670f',
-				parent: '67fdc72a1e49a2871aeb66cd',
-				content: '대댓글 테스트6',
-				quiz: '67fdc5ac1e49a2871aeb6651',
-				author: {
-					_id: '67e2e20e5872c849d5dd4b86',
-					nickname: 'test계정',
-				},
-				createdAt: '2025-04-15T02:47:34.588Z',
-				updatedAt: '2025-04-15T02:47:34.588Z',
-				__v: 0,
+	data: [
+		{
+			_id: '67fdc8c61e49a2871aeb670f',
+			parent: '67fdc72a1e49a2871aeb66cd',
+			content: '대댓글 테스트6',
+			quiz: '67fdc5ac1e49a2871aeb6651',
+			author: {
+				_id: '67e2e20e5872c849d5dd4b86',
+				nickname: 'test계정',
 			},
-		],
-		nextCursor: null,
-		totalCount: 1,
-	},
+			createdAt: '2025-04-15T02:47:34.588Z',
+			updatedAt: '2025-04-15T02:47:34.588Z',
+			__v: 0,
+		},
+	],
+	nextCursor: null,
+	totalCount: 1,
 };

--- a/src/modules/comment/comment.service.ts
+++ b/src/modules/comment/comment.service.ts
@@ -30,12 +30,14 @@ export class CommentService {
 				`상위 ${dto.commentId} Comment를 찾을 수 없습니다.`,
 			);
 
-		await this.commentRepo.create({
+		const comment = await this.commentRepo.create({
 			parent: toObjectId(dto.commentId),
 			content: dto.content,
 			quiz: toObjectId(dto.quizId),
 			author: toObjectId(userId),
 		});
+
+		return comment;
 	}
 
 	// 특정 Quiz에 대한 모든 최상위 Comment 조회

--- a/src/modules/comment/comment.service.ts
+++ b/src/modules/comment/comment.service.ts
@@ -84,10 +84,7 @@ export class CommentService {
 				dto,
 			);
 
-		return {
-			comment,
-			recomment: recommentList,
-		};
+		return recommentList;
 	}
 
 	// 사용자가 작성한 모든 Comment 조회

--- a/src/modules/quizbook/quizbook.controller.ts
+++ b/src/modules/quizbook/quizbook.controller.ts
@@ -20,6 +20,7 @@ import {
 	getQuizbookMetaDataEx,
 	getQuizbookStatesEx,
 	getQuizbookUserFlagsEx,
+	createQuizbookEx,
 } from './quizbook.example';
 
 @Controller({
@@ -36,7 +37,7 @@ export class QuizbookController {
 		summary: 'Quizbook 생성',
 		description: 'Quizbook 생성',
 	})
-	@ApiBaseResponse(201, '생성 성공')
+	@ApiBaseResponse(201, '생성 성공', createQuizbookEx)
 	createQuizbook(@Body() dto: CreateQuizbookDto, @UserId() userId: string) {
 		return this.quizbookService.createQuizbook(dto, userId);
 	}

--- a/src/modules/quizbook/quizbook.example.ts
+++ b/src/modules/quizbook/quizbook.example.ts
@@ -1,3 +1,25 @@
+export const createQuizbookEx = {
+	_id: '67fdc5ac1e49a2871aeb6657',
+	title: '면접 대비 CS 문제집',
+	description: '면접 대비하는 문제입니다.',
+	category: '웹 개발',
+	quizList: [
+		'67fdc5ac1e49a2871aeb6651',
+		'67fdc5ac1e49a2871aeb6652',
+		'67fdc5ac1e49a2871aeb6653',
+	],
+	solvedCount: 0,
+	solvedScore: 0,
+	totalScore: 60,
+	reviewCount: 0,
+	reviewScore: 0,
+	reviewRating: 0,
+	author: '67e2e20e5872c849d5dd4b86',
+	createdAt: '2025-04-15T02:34:20.113Z',
+	updatedAt: '2025-04-15T08:24:44.912Z',
+	__v: 0,
+};
+
 export const getQuizbookListEx = {
 	data: [
 		{

--- a/src/modules/quizbook/quizbook.service.ts
+++ b/src/modules/quizbook/quizbook.service.ts
@@ -53,7 +53,7 @@ export class QuizbookService {
 			);
 
 			// 2. Quizbook 생성
-			await this.quizbookRepo.create(
+			const quizbook = await this.quizbookRepo.create(
 				{
 					...dto,
 					quizList: quizList.map((q) => toObjectId(q._id as string)),
@@ -62,6 +62,8 @@ export class QuizbookService {
 				},
 				session,
 			);
+
+			return quizbook;
 		});
 	}
 

--- a/src/modules/review/review.controller.ts
+++ b/src/modules/review/review.controller.ts
@@ -16,7 +16,7 @@ import { ApiBaseResponse } from 'src/common/decorators/base-response.decorator';
 import { UserId } from 'src/common/decorators/user-id.decorator';
 import { Public } from '../auth/decorator/public.decorator';
 import { PaginationRequestDto } from 'src/common/dto/pagination.dto';
-import { getReviewListEx } from './review.example';
+import { createReviewEx, getReviewListEx } from './review.example';
 
 @Controller({
 	path: 'review',
@@ -33,7 +33,7 @@ export class ReviewController {
 		summary: 'Review 생성',
 		description: '특정 Quizbook에 대한 Review를 생성합니다.',
 	})
-	@ApiBaseResponse(201, '생성 성공')
+	@ApiBaseResponse(201, '생성 성공', createReviewEx)
 	createReview(@Body() dto: CreateReviewDto, @UserId() userId: string) {
 		return this.reviewService.createReview(dto, userId);
 	}

--- a/src/modules/review/review.example.ts
+++ b/src/modules/review/review.example.ts
@@ -1,3 +1,14 @@
+export const createReviewEx = {
+	_id: '67fe3c0c277a68a1ac3f4aa4',
+	score: 2.5,
+	content: '쏘쏘',
+	quizbook: '67fdc5ac1e49a2871aeb6657',
+	author: '67fe18f8bb486fc72e9a8004',
+	createdAt: '2025-04-15T10:59:24.969Z',
+	updatedAt: '2025-04-15T10:59:24.969Z',
+	__v: 0,
+};
+
 export const getReviewListEx = {
 	data: [
 		{

--- a/src/modules/review/review.service.ts
+++ b/src/modules/review/review.service.ts
@@ -67,6 +67,8 @@ export class ReviewService {
 				dto.quizbookId,
 				session,
 			);
+
+			return review;
 		});
 	}
 


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
- 프론트에서의 `mutation` 활용을 위해 생성 관련 API의 응답값에 `result` 필드를 추가합니다.

## 📌 이슈 넘버
- #63 

## 📝 작업 내용
- 리뷰 생성 시 응답값 수정
- 코멘트 생성 시 응답값 수정
- 문제집 생성 시 응답값 수정
