### PR TITLE
[Refactor] 메타데이터 조회 API 응답값에 createdAt 추가

### DIFF
--- a/src/modules/quizbook/quizbook.example.ts
+++ b/src/modules/quizbook/quizbook.example.ts
@@ -75,6 +75,7 @@ export const getQuizbookMetaDataEx = {
 		nickname: 'test2계정',
 		profileImg: '',
 	},
+	createdAt: '2025-04-15T02:34:20.113Z',
 };
 
 export const getQuizbookUserFlagsEx = {

--- a/src/modules/quizbook/quizbook.repository.ts
+++ b/src/modules/quizbook/quizbook.repository.ts
@@ -150,7 +150,9 @@ export class QuizbookRepository {
 	async findQuizbookWithMetaData(quizbookId: string) {
 		return this.quizbookModel
 			.findById(quizbookId)
-			.select('title category description totalScore author quizList')
+			.select(
+				'title category description totalScore author quizList createdAt',
+			)
 			.populate([
 				{
 					path: 'quizList',


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
- Quizbook 메타데이터 조회 API 응답값 수정

## 📝 작업 내용
- 요청에 의해 Quizbook 메타데이터 조회 API의 응답값에 `createdAt` 필드를 추가합니다.
