### PR TITLE
[Fix] 그룹 멤버별 점수 조회 API 오류 수정

### DIFF
--- a/src/modules/study/study.service.ts
+++ b/src/modules/study/study.service.ts
@@ -16,6 +16,7 @@ import { AIService } from '../ai/ai.service';
 import { QuizRepository } from '../quiz/quiz.repository';
 import { CategoryType } from '../quizbook/schema/quizbook.schema';
 import { UserRepository } from '../user/user.repository';
+import { User } from '../user/schema/user.schema';
 
 @Injectable()
 export class StudyService {
@@ -276,13 +277,15 @@ export class StudyService {
 				`해당 ${groupId}의 Group이 존재하지 않거나 멤버가 아닙니다.`,
 			);
 
+		const memberList = group.memberList.map((member) => member._id);
+
 		const result = await this.studyRepo.findQuizbookRecordListByUserList(
 			quizbookId,
-			group.memberList,
+			memberList,
 		);
 
 		return {
-			meberList: group.memberList,
+			memberList: group.memberList,
 			scoreList: result.map((record) => {
 				return {
 					score: record.score,


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
- 그룹 멤버별 점수 조회 API 오류 수정 합니다.

## 📝 작업 내용
- `memberList`의 `populate` 후 발생한 에러를 수정했습니다.
