### PR TITLE
[Feat] 그룹 관련 api 추가 및 수정

### DIFF
--- a/src/modules/group/group-quizbook/group-quizbook.controller.ts
+++ b/src/modules/group/group-quizbook/group-quizbook.controller.ts
@@ -13,7 +13,10 @@ import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { GroupQuizbookService } from './group-quizbook.service';
 import { ApiBaseResponse } from 'src/common/decorators/base-response.decorator';
 import { UserId } from 'src/common/decorators/user-id.decorator';
-import { GroupQuizbookListExample } from './group-quizbook.example';
+import {
+	GroupQuizbookExample,
+	GroupQuizbookListExample,
+} from './group-quizbook.example';
 import { CreateGroupQuizbookDto } from './dto/create-group-quizbook.dto';
 import { GroupQuizbookQueryDto } from './dto/group-quizbook-query.dto';
 
@@ -37,6 +40,24 @@ export class GroupQuizbookController {
 			userId,
 			groupId,
 			query,
+		);
+	}
+
+	@Get(':quizbookId')
+	@ApiOperation({
+		summary: '특정 Group 선정 문제집 정보 조회',
+		description: '특정 Group 선정 문제집 정보를 조회합니다.',
+	})
+	@ApiBaseResponse(HttpStatus.OK, '조회 성공', GroupQuizbookExample)
+	getGroupQuizbook(
+		@UserId() userId: string,
+		@Param('groupId') groupId: string,
+		@Param('quizbookId') quizbookId: string,
+	) {
+		return this.groupQuizbookService.getGroupQuizbook(
+			userId,
+			groupId,
+			quizbookId,
 		);
 	}
 

--- a/src/modules/group/group-quizbook/group-quizbook.example.ts
+++ b/src/modules/group/group-quizbook/group-quizbook.example.ts
@@ -26,3 +26,25 @@ export const GroupQuizbookListExample = {
 	nextCursor: '2025-04-02',
 	leftCount: 24,
 };
+
+export const GroupQuizbookExample = {
+	group: '65e8a5d6fc13ae5e7f000002',
+	quizbook: {
+		_id: '65e8a5d6fc13ae5e7f000002',
+		title: '알고리즘 문제집',
+		description: '면접 준비용',
+		category: '알고리즘',
+		quizList: [
+			{
+				_id: '68003e7b56ae18a5b75151cf',
+				type: '주관식',
+				question:
+					'다음 설명에 해당하는 용어는 무엇인가요? 연결 지향적이고 신뢰성이 높은 전송 프로토콜로, 패킷 순서 보장과 오류 제어 기능을 제공합니다.',
+				answer: 'TCP',
+				optionList: [],
+			},
+		],
+		author: '65e8a5d6fc13ae5e7f000002',
+	},
+	endedAt: '2025-04-02',
+};

--- a/src/modules/group/group-quizbook/group-quizbook.module.ts
+++ b/src/modules/group/group-quizbook/group-quizbook.module.ts
@@ -10,6 +10,7 @@ import { DB_TYPE } from 'src/database/database.const';
 import { DatabaseModule } from 'src/database/database.module';
 import { GroupQuizbookRepository } from './group-quizbook.repository';
 import { GroupModule } from '../group.module';
+import { QuizbookModule } from 'src/modules/quizbook/quizbook.module';
 
 @Module({
 	imports: [
@@ -19,6 +20,7 @@ import { GroupModule } from '../group.module';
 		),
 		DatabaseModule,
 		forwardRef(() => GroupModule),
+		forwardRef(() => QuizbookModule),
 	],
 	controllers: [GroupQuizbookController],
 	providers: [GroupQuizbookService, GroupQuizbookRepository],

--- a/src/modules/group/group-quizbook/group-quizbook.repository.ts
+++ b/src/modules/group/group-quizbook/group-quizbook.repository.ts
@@ -64,7 +64,27 @@ export class GroupQuizbookRepository {
 						select: 'nickname profileImg',
 					},
 				},
-			]);
+			])
+			.lean();
+	}
+
+	/**
+	 * 특정 Group 선정 문제집 정보 조회
+	 */
+	async findGroupQuizbook(group: Types.ObjectId, quizbook: Types.ObjectId) {
+		return this.groupQuizbookModel.findOne({ group, quizbook }).populate([
+			{
+				path: 'quizbook',
+				model: 'Quizbook',
+				populate: [
+					{
+						path: 'quizList',
+						model: 'Quiz',
+						select: 'type question answer optionList',
+					},
+				],
+			},
+		]);
 	}
 
 	/**

--- a/src/modules/group/group-quizbook/group-quizbook.service.ts
+++ b/src/modules/group/group-quizbook/group-quizbook.service.ts
@@ -10,6 +10,9 @@ import { GroupRepository } from '../group.repository';
 import { toObjectId } from 'src/common/utils/database.util';
 import { GroupQuizbookQueryDto } from './dto/group-quizbook-query.dto';
 import { GroupQuizbook } from './schema/group-quizbook.schema';
+import { QuizbookService } from 'src/modules/quizbook/quizbook.service';
+import { Quizbook } from 'src/modules/quizbook/schema/quizbook.schema';
+import { Types } from 'mongoose';
 
 @Injectable()
 export class GroupQuizbookService {
@@ -17,6 +20,7 @@ export class GroupQuizbookService {
 		private readonly groupQuizbookRepository: GroupQuizbookRepository,
 		private readonly databaseService: DatabaseService,
 		private readonly groupRepository: GroupRepository,
+		private readonly quizbookService: QuizbookService,
 	) {}
 
 	async getGroupQuizbookList(
@@ -51,6 +55,20 @@ export class GroupQuizbookService {
 				cursor ? new Date(cursor) : undefined,
 			);
 
+		const resultGroupQuizbookList = await Promise.all(
+			groupQuizbookList.map(async (data: GroupQuizbook) => {
+				return {
+					_id: data._id,
+					group: data.group,
+					quizbook: await this.quizbookService.addUserFlagsToQuizbook(
+						data.quizbook as Quizbook,
+						userId,
+					),
+					endedAt: data.endedAt,
+				};
+			}),
+		);
+
 		const leftCount = await this.groupQuizbookRepository.findLeftCount(
 			toObjectId(groupId),
 			new Date(standard),
@@ -60,13 +78,49 @@ export class GroupQuizbookService {
 		);
 
 		return {
-			list: groupQuizbookList,
+			list: resultGroupQuizbookList,
 			nextCursor:
-				groupQuizbookList.length > 0
-					? groupQuizbookList[groupQuizbookList.length - 1].endedAt
+				resultGroupQuizbookList.length > 0
+					? resultGroupQuizbookList[
+							resultGroupQuizbookList.length - 1
+						].endedAt
 					: null,
-			leftCount: leftCount - groupQuizbookList.length,
+			leftCount: leftCount - resultGroupQuizbookList.length,
 		};
+	}
+
+	async getGroupQuizbook(
+		userId: string,
+		groupId: string,
+		quizbookId: string,
+	) {
+		const group = await this.groupRepository.findById(groupId);
+
+		if (!group)
+			throw new NotFoundException(
+				`해당 ${groupId} Group을 찾을 수 없습니다.`,
+			);
+
+		const targetMemberList = group.memberList.map((user) =>
+			user._id.toString(),
+		);
+		const indexOfNewOwner = targetMemberList.indexOf(userId);
+
+		if (indexOfNewOwner === -1)
+			throw new UnauthorizedException(`허가되지 않는 접근입니다.`);
+
+		const groupQuizbook =
+			await this.groupQuizbookRepository.findGroupQuizbook(
+				toObjectId(groupId),
+				toObjectId(quizbookId),
+			);
+
+		if (!groupQuizbook)
+			throw new NotFoundException(
+				`존재하지 않는 그룹 선정 문제집입니다.`,
+			);
+
+		return groupQuizbook;
 	}
 
 	async postCreateGroupQuizbook(
@@ -86,7 +140,8 @@ export class GroupQuizbookService {
 			throw new UnauthorizedException(`허가되지 않는 접근입니다.`);
 
 		const targetGroupQuizbookList = group.groupQuizbookList.map(
-			(data: GroupQuizbook) => data.quizbook.toString(),
+			(data: GroupQuizbook) =>
+				(data.quizbook as Types.ObjectId).toString(),
 		);
 		const index = targetGroupQuizbookList.indexOf(quizbookId);
 		if (index !== -1)

--- a/src/modules/group/group-quizbook/schema/group-quizbook.schema.ts
+++ b/src/modules/group/group-quizbook/schema/group-quizbook.schema.ts
@@ -1,5 +1,6 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document, Types } from 'mongoose';
+import { Quizbook } from 'src/modules/quizbook/schema/quizbook.schema';
 
 @Schema({ timestamps: true })
 export class GroupQuizbook extends Document {
@@ -7,7 +8,7 @@ export class GroupQuizbook extends Document {
 	group: Types.ObjectId;
 
 	@Prop({ type: Types.ObjectId, ref: 'Quizbook', required: true })
-	quizbook: Types.ObjectId;
+	quizbook: Types.ObjectId | Quizbook;
 
 	@Prop({
 		type: Date,

--- a/src/modules/group/group.service.ts
+++ b/src/modules/group/group.service.ts
@@ -373,7 +373,7 @@ export class GroupService {
 		);
 
 		return {
-			url: `${clientUrl}/login?token=${token}`,
+			url: `${clientUrl}/group/invitation?token=${token}`,
 		};
 	}
 

--- a/src/modules/study/study.repository.ts
+++ b/src/modules/study/study.repository.ts
@@ -180,7 +180,7 @@ export class StudyRepository {
 				quiz: toObjectId(quizId),
 				$and: [
 					{ owner: { $in: userList } },
-					{ owner: { $ne: toObjectId(userId) } },
+					// { owner: { $ne: toObjectId(userId) } },
 				],
 			})
 			.populate({


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

- 그룹 관련 api를 추가 및 수정했습니다.

## 📌 이슈 넘버

- #78 

## 📝 작업 내용

- 그룹 선정 문제집 정보 조회 api 추가
- 그룹 선정 문제집 리스트 조회 api 반환값 수정 (quizbook populate)
- 특정 Quiz에 대한 그룹원 답안 조회 api 수정 (요청자의 답안 포함 시키기)
- 그룹 초대 url 조회 api 수정 (반환 url 경로 수정)

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

close #78 
