### PR TITLE
[Fix] 작업을 위해 사용한 코드 정리 및 로그아웃 쿠키 제거

### DIFF
--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -238,24 +238,18 @@ export class AuthService {
 		{ accessToken, refreshToken }: AuthToken,
 		response: Response,
 	) {
-		try {
-			response.cookie(AUTH_COOKIE_KEY.ACCESS, accessToken, {
-				...AUTH_COOKIE_OPTIONS.ACCESS,
-				domain: this.hostname,
-				sameSite: this.env === 'prod' ? 'none' : 'lax',
-				secure: this.env === 'prod',
-			});
-			response.cookie(AUTH_COOKIE_KEY.REFRESH, refreshToken, {
-				...AUTH_COOKIE_OPTIONS.REFRESH,
-				domain: this.hostname,
-				sameSite: this.env === 'prod' ? 'none' : 'lax',
-				secure: this.env === 'prod',
-			});
-		} catch (error) {
-			if (error instanceof Error) {
-				console.error(error.stack);
-			}
-		}
+		response.cookie(AUTH_COOKIE_KEY.ACCESS, accessToken, {
+			...AUTH_COOKIE_OPTIONS.ACCESS,
+			domain: this.hostname,
+			sameSite: this.env === 'prod' ? 'none' : 'lax',
+			secure: this.env === 'prod',
+		});
+		response.cookie(AUTH_COOKIE_KEY.REFRESH, refreshToken, {
+			...AUTH_COOKIE_OPTIONS.REFRESH,
+			domain: this.hostname,
+			sameSite: this.env === 'prod' ? 'none' : 'lax',
+			secure: this.env === 'prod',
+		});
 	}
 
 	/**

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -272,8 +272,16 @@ export class AuthService {
 	) {
 		const { access_token, refresh_token } = cookies;
 
-		response.clearCookie(AUTH_COOKIE_KEY.ACCESS);
-		response.clearCookie(AUTH_COOKIE_KEY.REFRESH);
+		response.clearCookie(AUTH_COOKIE_KEY.ACCESS, {
+			domain: this.hostname,
+			sameSite: this.env === 'prod' ? 'none' : 'lax',
+			secure: this.env === 'prod',
+		});
+		response.clearCookie(AUTH_COOKIE_KEY.REFRESH, {
+			domain: this.hostname,
+			sameSite: this.env === 'prod' ? 'none' : 'lax',
+			secure: this.env === 'prod',
+		});
 
 		// 토큰 만료
 		if (access_token) {

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -1,5 +1,5 @@
 import * as bcrypt from 'bcrypt';
-import { Response } from 'express';
+import { CookieOptions, Response } from 'express';
 import {
 	BadRequestException,
 	ConflictException,
@@ -27,8 +27,7 @@ import { ChangePasswordDto } from '../user/dto/change-password.dto';
 
 @Injectable()
 export class AuthService {
-	private readonly env: string;
-	private readonly hostname: string;
+	private readonly defaultCookieOptions: CookieOptions;
 
 	constructor(
 		private readonly configService: ConfigService,
@@ -39,12 +38,17 @@ export class AuthService {
 		private readonly followService: FollowService,
 		private readonly groupService: GroupService,
 	) {
-		this.env = configService.get(envKeys.ENV)!;
-		this.hostname = new URL(
-			this.env === 'prod'
+		const env = configService.get<'dev' | 'prod'>(envKeys.ENV)!;
+		const hostname = new URL(
+			env === 'prod'
 				? configService.get(envKeys.CLIENT.PROD)!
 				: configService.get(envKeys.CLIENT.LOCAL)!,
 		).hostname;
+		this.defaultCookieOptions = {
+			domain: hostname,
+			sameSite: env === 'prod' ? 'none' : 'lax',
+			secure: env === 'prod',
+		};
 	}
 
 	/**
@@ -240,15 +244,11 @@ export class AuthService {
 	) {
 		response.cookie(AUTH_COOKIE_KEY.ACCESS, accessToken, {
 			...AUTH_COOKIE_OPTIONS.ACCESS,
-			domain: this.hostname,
-			sameSite: this.env === 'prod' ? 'none' : 'lax',
-			secure: this.env === 'prod',
+			...this.defaultCookieOptions,
 		});
 		response.cookie(AUTH_COOKIE_KEY.REFRESH, refreshToken, {
 			...AUTH_COOKIE_OPTIONS.REFRESH,
-			domain: this.hostname,
-			sameSite: this.env === 'prod' ? 'none' : 'lax',
-			secure: this.env === 'prod',
+			...this.defaultCookieOptions,
 		});
 	}
 
@@ -266,16 +266,11 @@ export class AuthService {
 	) {
 		const { access_token, refresh_token } = cookies;
 
-		response.clearCookie(AUTH_COOKIE_KEY.ACCESS, {
-			domain: this.hostname,
-			sameSite: this.env === 'prod' ? 'none' : 'lax',
-			secure: this.env === 'prod',
-		});
-		response.clearCookie(AUTH_COOKIE_KEY.REFRESH, {
-			domain: this.hostname,
-			sameSite: this.env === 'prod' ? 'none' : 'lax',
-			secure: this.env === 'prod',
-		});
+		response.clearCookie(AUTH_COOKIE_KEY.ACCESS, this.defaultCookieOptions);
+		response.clearCookie(
+			AUTH_COOKIE_KEY.REFRESH,
+			this.defaultCookieOptions,
+		);
 
 		// 토큰 만료
 		if (access_token) {


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

쿠키 적용 작업을 위해 사용한 테스트 코드를 정리하고, 로그아웃(회원탈퇴) 시 쿠키가 제거되지 않는 현상을 수정했습니다.

## 📌 이슈 넘버

- #85

## 📝 작업 내용

### 테스트 코드 정리

테스트 시 사용한 `try catch`를 제거했습니다.

### 로그아웃(회원탈퇴) 시 쿠키가 제거되지 않는 현상 수정

로그아웃 시 실제로 token은 만료처리되었지만 브라우저의 쿠키가 제거되지 않아 user/me에서 401 오류가 발생하는 현상을 수정했습니다. 

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

