### PR TITLE
[Feat] 동적 sitemap을 위한 엔드포인트 추가

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -23,6 +23,7 @@ import { CategoryModule } from './modules/category/category.module';
 import { FollowModule } from './modules/follow/follow.module';
 import { ChatModule } from './modules/chat/chat.module';
 import { AIModule } from './modules/ai/ai.module';
+import { SitemapModule } from './modules/sitemap/sitemap.module';
 
 @Module({
 	imports: [
@@ -46,6 +47,7 @@ import { AIModule } from './modules/ai/ai.module';
 		FollowModule,
 		ChatModule,
 		AIModule,
+		SitemapModule,
 	],
 	providers: [
 		{

--- a/src/modules/quizbook/quizbook.module.ts
+++ b/src/modules/quizbook/quizbook.module.ts
@@ -12,6 +12,7 @@ import { StudyModule } from '../study/study.module';
 import { AIModule } from '../ai/ai.module';
 import { GroupModule } from '../group/group.module';
 import { GroupQuizbookModule } from '../group/group-quizbook/group-quizbook.module';
+import { SitemapModule } from '../sitemap/sitemap.module';
 
 @Module({
 	imports: [
@@ -25,6 +26,7 @@ import { GroupQuizbookModule } from '../group/group-quizbook/group-quizbook.modu
 		forwardRef(() => AIModule),
 		forwardRef(() => GroupModule),
 		forwardRef(() => GroupQuizbookModule),
+		forwardRef(() => SitemapModule),
 		DatabaseModule,
 	],
 	controllers: [QuizbookController],

--- a/src/modules/quizbook/quizbook.repository.ts
+++ b/src/modules/quizbook/quizbook.repository.ts
@@ -179,4 +179,11 @@ export class QuizbookRepository {
 			)
 			.lean();
 	}
+
+	/**
+	 * 모든 Quizbook 리스트 조회(Default)
+	 */
+	async findQuizbookList() {
+		return this.quizbookModel.find().select('_id').lean();
+	}
 }

--- a/src/modules/quizbook/quizbook.service.ts
+++ b/src/modules/quizbook/quizbook.service.ts
@@ -213,4 +213,11 @@ export class QuizbookService {
 			data: quizbookList,
 		};
 	}
+
+	// 모든 Quizbook의 Id 리스트 조회
+	async getQuizbookIdList() {
+		const quizbookList = await this.quizbookRepo.findQuizbookList();
+
+		return quizbookList.map((q) => (q._id as Types.ObjectId).toString());
+	}
 }

--- a/src/modules/quizbook/quizbook.service.ts
+++ b/src/modules/quizbook/quizbook.service.ts
@@ -15,6 +15,7 @@ import { AIService } from '../ai/ai.service';
 import { getXpByType } from '../study/utils/study.utils';
 import { GroupRepository } from '../group/group.repository';
 import { GroupQuizbookRepository } from '../group/group-quizbook/group-quizbook.repository';
+import { SitemapRepository } from '../sitemap/sitemap.repository';
 
 @Injectable()
 export class QuizbookService {
@@ -25,6 +26,7 @@ export class QuizbookService {
 		private readonly studyRepo: StudyRepository,
 		private readonly groupRepo: GroupRepository,
 		private readonly groupQuizbookRepo: GroupQuizbookRepository,
+		private readonly sitemapRepo: SitemapRepository,
 		private readonly aiService: AIService,
 		private readonly databaseService: DatabaseService,
 	) {}
@@ -64,6 +66,9 @@ export class QuizbookService {
 				},
 				session,
 			);
+
+			// 3. Sitemap 캐시 업데이트 필요 명시
+			await this.sitemapRepo.markNeedsUpdate();
 
 			return quizbook;
 		});

--- a/src/modules/sitemap/schema/sitemap-cache.schema.ts
+++ b/src/modules/sitemap/schema/sitemap-cache.schema.ts
@@ -1,0 +1,13 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+@Schema({ timestamps: true })
+export class SitemapCache extends Document {
+	@Prop({ type: [String], required: true })
+	quizbookIdList: string[];
+
+	@Prop({ default: Date.now })
+	updatedAt: Date;
+}
+
+export const SitemapCacheSchema = SchemaFactory.createForClass(SitemapCache);

--- a/src/modules/sitemap/schema/sitemap-cache.schema.ts
+++ b/src/modules/sitemap/schema/sitemap-cache.schema.ts
@@ -6,8 +6,8 @@ export class SitemapCache extends Document {
 	@Prop({ type: [String], required: true })
 	quizbookIdList: string[];
 
-	@Prop({ default: Date.now })
-	updatedAt: Date;
+	@Prop({ type: Boolean, default: false })
+	needsUpdate: boolean;
 }
 
 export const SitemapCacheSchema = SchemaFactory.createForClass(SitemapCache);

--- a/src/modules/sitemap/sitemap.controller.ts
+++ b/src/modules/sitemap/sitemap.controller.ts
@@ -1,0 +1,24 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { SitemapService } from './sitemap.service';
+import { Public } from '../auth/decorator/public.decorator';
+
+@Controller({
+	path: 'sitemap',
+	version: '1',
+})
+@ApiTags('Sitemap')
+export class SitemapController {
+	constructor(private readonly sitemapService: SitemapService) {}
+
+	@Public()
+	@Get()
+	async getQuizbookIdList() {
+		const quizbookIdList =
+			await this.sitemapService.getQuizbookIdListForSitemap();
+
+		return {
+			quizbookIdList,
+		};
+	}
+}

--- a/src/modules/sitemap/sitemap.module.ts
+++ b/src/modules/sitemap/sitemap.module.ts
@@ -1,0 +1,25 @@
+import { forwardRef, Module } from '@nestjs/common';
+import { QuizbookModule } from '../quizbook/quizbook.module';
+import { SitemapController } from './sitemap.controller';
+import { SitemapService } from './sitemap.service';
+import { MongooseModule } from '@nestjs/mongoose';
+import { DB_TYPE } from 'src/database/database.const';
+import {
+	SitemapCache,
+	SitemapCacheSchema,
+} from './schema/sitemap-cache.schema';
+import { SitemapRepository } from './sitemap.repository';
+
+@Module({
+	imports: [
+		MongooseModule.forFeature(
+			[{ name: SitemapCache.name, schema: SitemapCacheSchema }],
+			DB_TYPE.DEFAULT,
+		),
+		forwardRef(() => QuizbookModule),
+	],
+	controllers: [SitemapController],
+	providers: [SitemapService, SitemapRepository],
+	exports: [SitemapService, SitemapRepository],
+})
+export class SitemapModule {}

--- a/src/modules/sitemap/sitemap.repository.ts
+++ b/src/modules/sitemap/sitemap.repository.ts
@@ -12,9 +12,7 @@ export class SitemapRepository {
 	) {}
 
 	async getCache() {
-		const data = await this.sitemapCacheModel.findOne().lean();
-
-		return data?.quizbookIdList ?? [];
+		return await this.sitemapCacheModel.findOne().lean();
 	}
 
 	async saveCache(quizbookIdList: string[]) {
@@ -22,9 +20,17 @@ export class SitemapRepository {
 			{},
 			{
 				quizbookIdList,
-				updatedAt: new Date(),
+				needsUpdate: false,
 			},
 			{ upsert: true, new: true },
+		);
+	}
+
+	async markNeedsUpdate() {
+		await this.sitemapCacheModel.updateOne(
+			{},
+			{ needsUpdate: true },
+			{ upsert: true },
 		);
 	}
 }

--- a/src/modules/sitemap/sitemap.repository.ts
+++ b/src/modules/sitemap/sitemap.repository.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { SitemapCache } from './schema/sitemap-cache.schema';
+import { DB_TYPE } from 'src/database/database.const';
+import { Model } from 'mongoose';
+
+@Injectable()
+export class SitemapRepository {
+	constructor(
+		@InjectModel(SitemapCache.name, DB_TYPE.DEFAULT)
+		private readonly sitemapCacheModel: Model<SitemapCache>,
+	) {}
+
+	async getCache() {
+		const data = await this.sitemapCacheModel.findOne().lean();
+
+		return data?.quizbookIdList ?? [];
+	}
+
+	async saveCache(quizbookIdList: string[]) {
+		await this.sitemapCacheModel.findOneAndUpdate(
+			{},
+			{
+				quizbookIdList,
+				updatedAt: new Date(),
+			},
+			{ upsert: true, new: true },
+		);
+	}
+}

--- a/src/modules/sitemap/sitemap.service.ts
+++ b/src/modules/sitemap/sitemap.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { QuizbookService } from '../quizbook/quizbook.service';
+import { SitemapRepository } from './sitemap.repository';
+
+@Injectable()
+export class SitemapService {
+	constructor(
+		private readonly quizbookService: QuizbookService,
+		private readonly sitemapRepo: SitemapRepository,
+	) {}
+
+	// 캐시 된 QuizbookList 조회
+	async getQuizbookIdListForSitemap() {
+		const curList = await this.quizbookService.getQuizbookIdList();
+		const cachedList = await this.sitemapRepo.getCache();
+
+		const isChanged =
+			curList.length !== cachedList.length ||
+			curList.some((id, i) => id !== cachedList[i]);
+
+		if (isChanged) {
+			await this.sitemapRepo.saveCache(curList);
+		}
+
+		return curList;
+	}
+}

--- a/src/modules/sitemap/sitemap.service.ts
+++ b/src/modules/sitemap/sitemap.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
-import { QuizbookService } from '../quizbook/quizbook.service';
 import { SitemapRepository } from './sitemap.repository';
+import { QuizbookService } from '../quizbook/quizbook.service';
 
 @Injectable()
 export class SitemapService {
@@ -9,19 +9,18 @@ export class SitemapService {
 		private readonly sitemapRepo: SitemapRepository,
 	) {}
 
-	// 캐시 된 QuizbookList 조회
 	async getQuizbookIdListForSitemap() {
-		const curList = await this.quizbookService.getQuizbookIdList();
-		const cachedList = await this.sitemapRepo.getCache();
+		const cached = await this.sitemapRepo.getCache();
 
-		const isChanged =
-			curList.length !== cachedList.length ||
-			curList.some((id, i) => id !== cachedList[i]);
+		if (!cached || cached.needsUpdate) {
+			const quizbookIdList =
+				await this.quizbookService.getQuizbookIdList();
 
-		if (isChanged) {
-			await this.sitemapRepo.saveCache(curList);
+			await this.sitemapRepo.saveCache(quizbookIdList);
+
+			return quizbookIdList;
 		}
 
-		return curList;
+		return cached.quizbookIdList;
 	}
 }


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
- 프론트엔드에서 동적 사이트맵 구성을 위한 모든 quizbook의 Id 리스트를 캐싱하는 로직을 추가 했습니다.